### PR TITLE
Copy intermediate variables from blockette memory

### DIFF
--- a/src/NKSolver/NKSolvers.F90
+++ b/src/NKSolver/NKSolvers.F90
@@ -312,7 +312,7 @@ contains
     end do spectralLoop4b
 
     ! Evaluate the residual now
-    call computeResidualNK()
+    call computeResidualNK(useUpdateIntermed = .True.)
     call getCurrentResidual(rhoRes, totalRRes)
 
     ! Put everything back
@@ -444,7 +444,7 @@ contains
     ! computeResidualNK subroutine
 
     call setW(wVec)
-    call computeResidualNK()
+    call computeResidualNK(useUpdateIntermed = .False.)
     call setRVec(rVec)
     ! We don't check an error here, so just pass back zero
     ierr = 0
@@ -532,7 +532,7 @@ contains
 
        ! Evaluate the residual before we start and put the residual in
        ! 'g', which is what would be the case after a linesearch.
-       call computeResidualNK()
+       call computeResidualNK(useUpdateIntermed = .False.)
        call setRVec(rVec)
        iter_k = 1
        iter_m = 0
@@ -718,7 +718,7 @@ contains
 
     ! Compute Function:
     call setW(w)
-    call computeResidualNK()
+    call computeResidualNK(useUpdateIntermed = .True.)
     call setRVec(g, flowRes2, turbRes2, gnorm)
 
     nfevals = nfevals + 1
@@ -761,7 +761,7 @@ contains
 
           ! Compute Function
           call setW(w)
-          call computeResidualNK()
+          call computeResidualNK(useUpdateIntermed = .True.)
           call setRVec(g, flowRes2, turbRes2, gnorm)
 
           nfevals = nfevals + 1
@@ -831,7 +831,7 @@ contains
 
     ! Compute new function again:
     call setW(w)
-    call computeResidualNK()
+    call computeResidualNK(useUpdateIntermed = .True.)
     call setRVec(g)
 
     nfevals = nfevals + 1
@@ -896,7 +896,7 @@ contains
 #endif
        ! Compute new function again:
        call setW(w)
-       call computeResidualNK()
+       call computeResidualNK(useUpdateIntermed = .True.)
        call setRVec(g)
        nfevals = nfevals + 1
 
@@ -943,7 +943,7 @@ contains
 
     ! Compute new function:
     call setW(w)
-    call computeResidualNK()
+    call computeResidualNK(useUpdateIntermed = .True.)
     call setRVec(g)
 
     nfevals = nfevals + 1
@@ -1016,7 +1016,7 @@ contains
 
        ! Compute Function @ new x (w is the work vector
        call setW(w)
-       call computeResidualNK()
+       call computeResidualNK(useUpdateIntermed = .True.)
        call setRVec(g)
        nfevals = nfevals + 1
 
@@ -1046,19 +1046,24 @@ contains
     step = alpha
   end subroutine LSNM
 
-  subroutine computeResidualNK()
+  subroutine computeResidualNK(useUpdateIntermed)
 
     use constants
     use blockette, only : blocketteRes
     implicit none
 
-    logical :: updateDt
+    logical, intent(in), optional :: useUpdateIntermed
+    logical :: updateIntermed
 
-    ! We want to update the time step
-    updateDt = .true.
+    ! Only update the time step if explicitly requested
+    updateIntermed = .false.
+
+    if (present(useUpdateIntermed)) then
+      updateIntermed = useUpdateIntermed
+    end if
 
     ! Shell function to maintain backward compatibility with code using computeResidualNK
-    call blocketteRes(useUpdateDT = updateDt)
+    call blocketteRes(useUpdateIntermed = updateIntermed)
 
   end subroutine computeResidualNK
 
@@ -1389,7 +1394,7 @@ contains
     integer(kind=intType) :: nn,i,j,k,l,counter,sps
     real(kind=realType) :: ovv
 
-    call computeResidualNK()
+    call computeResidualNK(useUpdateIntermed = .True.)
     counter = 0
     do nn=1,nDom
        do sps=1,nTimeIntervalsSpectral
@@ -3611,7 +3616,7 @@ contains
        call setwVecANK(wVec,1,nstate)
 
        ! Evaluate the residual before we start
-       call blocketteRes(useUpdateDt=.True.)
+       call blocketteRes(useUpdateIntermed=.True.)
        if (ANK_coupled) then
           call setRvec(rVec)
        else
@@ -3933,7 +3938,7 @@ contains
     ! also need the to update the update the time step and the
     ! viscWall pointer stuff
 
-    call blocketteRes(useUpdateDt=.True.)
+    call blocketteRes(useUpdateIntermed=.True.)
 
     feval = feval + 1
     if (ANK_coupled) then

--- a/src/NKSolver/blockette.F90
+++ b/src/NKSolver/blockette.F90
@@ -67,7 +67,7 @@ module blockette
   !$OMP THREADPRIVATE(sI, sJ, sK, ux, uy, uz, vx, vy, vz, wx, wy, wz, qx, qy, qz)
 contains
 
-  subroutine blocketteRes(useDissApprox, useViscApprox, useUpdateDt, useFlowRes, useTurbRes, useSpatial, &
+  subroutine blocketteRes(useDissApprox, useViscApprox, useUpdateIntermed, useFlowRes, useTurbRes, useSpatial, &
        useStoreWall, famLists, funcValues, forces, bcDataNames, bcDataValues, bcDataFamLists)
 
     ! Copy the values from blockPointers (assumed set) into the
@@ -100,7 +100,7 @@ contains
     implicit none
 
     ! Input/Output
-    logical, intent(in), optional :: useDissApprox, useViscApprox, useUpdateDt, useFlowRes
+    logical, intent(in), optional :: useDissApprox, useViscApprox, useUpdateIntermed, useFlowRes
     logical, intent(in), optional :: useTurbRes, useSpatial, useStoreWall
     integer(kind=intType), optional, dimension(:, :), intent(in) :: famLists
     real(kind=realType), optional, dimension(:, :), intent(out) :: funcValues
@@ -110,7 +110,7 @@ contains
     real(kind=realType), intent(out), optional, dimension(:, :, :) :: forces
 
     ! Misc
-    logical :: dissApprox, viscApprox, updateDt, flowRes, turbRes, spatial, storeWall
+    logical :: dissApprox, viscApprox, updateIntermed, flowRes, turbRes, spatial, storeWall
     integer(kind=intType) :: nn, sps, fSize, lstart, lend, iRegion
     real(kind=realType) ::  pLocal
 
@@ -119,7 +119,16 @@ contains
     ! timeStep.
     dissApprox = .False.
     viscApprox = .False.
-    updateDt = .False.
+    ! Update intermediate flag is to copy out intermediate variables
+    ! that are computed during the blockette residual computation from
+    ! blockette memory back to the main memory. These are the time
+    ! step, spectral radii for all cases, and nodal gradients and
+    ! speed of sound squared for viscous simulations. The regular
+    ! "block" residuals do not need to copy out these since they
+    ! are already computed in place. For the block residual, this
+    ! flag only determines if we update the time step along with
+    ! the spectral radii.
+    updateIntermed = .False.
     flowRes = .True.
     turbRes = .True.
     spatial = .False.
@@ -134,8 +143,8 @@ contains
        viscApprox = useViscApprox
     end if
 
-    if (present(useUpdateDt)) then
-       updateDt = useUpdateDt
+    if (present(useUpdateIntermed)) then
+      updateIntermed = useUpdateIntermed
     end if
 
     if (present(useFlowRes)) then
@@ -261,9 +270,9 @@ contains
 
           rFil = one
           blockettes: if (useBlockettes) then
-             call blocketteResCore(dissApprox, viscApprox, updateDt, flowRes, turbRes, storeWall)
+             call blocketteResCore(dissApprox, viscApprox, updateIntermed, flowRes, turbRes, storeWall)
           else
-             call blockResCore(dissApprox, viscApprox, updateDt, flowRes, turbRes, storeWall, nn, sps)
+             call blockResCore(dissApprox, viscApprox, updateIntermed, flowRes, turbRes, storeWall, nn, sps)
           end if blockettes
 
           if (currentLevel == 1) then
@@ -288,7 +297,7 @@ contains
     end if
   end subroutine blocketteRes
 
-  subroutine blocketteResCore(dissApprox, viscApprox, updateDt, flowRes, turbRes, storeWall)
+  subroutine blocketteResCore(dissApprox, viscApprox, updateIntermed, flowRes, turbRes, storeWall)
 
     ! Main subroutine for computing the reisdual for the given block using blockettes
     use constants
@@ -301,12 +310,16 @@ contains
          bib=>ib, bjb=>jb, bkb=>kb, &
          bw=>w, bp=>p, bgamma=>gamma, &
          bradi=>radi, bradj=>radj, bradk=>radk, &
+         bux=>ux, buy=>uy, buz=>uz, &
+         bvx=>vx, bvy=>vy, bvz=>vz, &
+         bwx=>wx, bwy=>wy, bwz=>wz, &
+         bqx=>qx, bqy=>qy, bqz=>qz, &
          bx=>x, brlv=>rlv, brev=>rev, bvol=>vol, bVolRef=>volRef, bd2wall=>d2wall, &
          biblank=>iblank, bPorI=>porI, bPorJ=>porJ, bPorK=>porK, bdw=>dw, bfw=>fw, &
          bShockSensor=>shockSensor, &
          bsi=>si, bsj=>sj, bsk=>sk, &
          bsFaceI=>sFaceI, bsFaceJ=>sFaceJ, bsFaceK=>sFaceK , &
-         bdtl=>dtl,  &
+         bdtl=>dtl, baa=>aa, &
          addGridVelocities
     use flowVarRefState, only : nwf, nw, viscous, nt1, nt2
     use iteration, only : currentLevel
@@ -319,7 +332,7 @@ contains
     implicit none
 
     ! Input
-    logical, intent(in) :: dissApprox, viscApprox, updateDt, flowRes, turbRes, storeWall
+    logical, intent(in) :: dissApprox, viscApprox, updateIntermed, flowRes, turbRes, storeWall
 
     ! Working:
     integer(kind=intType) :: i, j, k, l, lStart, lEnd
@@ -616,7 +629,7 @@ contains
                 end select
              endif
 
-             call timeStep(updateDt)
+             call timeStep(updateIntermed)
 
              if (flowRes) then
                 call inviscidCentralFlux
@@ -666,23 +679,25 @@ contains
                 end do
              end do
 
-             ! Also copy out the dtl if we were asked for it
-             if (updateDt) then
-                do k=2, kl
-                   do j=2, jl
-                      do i=2, il
-                         bdtl(i+ii-2, j+jj-2, k+kk-2) = dtl(i, j, k)
-                      end do
-                   end do
-                end do
+             ! Also copy out the intermediate variables if asked for them
+             ! we need these to be updated in main memory because
+             ! the reverse mode AD routines do use these variables.
+             ! after every ANK and NK step, blocketteRes is called
+             ! with updateIntermed = True, and it will update these
+             ! arrays in main memory. The time step is required
+             ! for the ANK and MG solver steps.
+             intermed: if (updateIntermed) then
+               ! time step
+               do k=2, kl
+                  do j=2, jl
+                     do i=2, il
+                        bdtl(i+ii-2, j+jj-2, k+kk-2) = dtl(i, j, k)
+                     end do
+                  end do
+               end do
 
-                ! also copy rad i j k
-                ! we need these to be updated in main memory because
-                ! the reverse mode AD routines do use these variables.
-                ! after every ANK and NK step, blocketteRes is called
-                ! with updateDt = True, and it will update these
-                ! arrays in main memory.
-                do k=1, ke
+               ! Spectral radii
+               do k=1, ke
                   do j=1, je
                      do i=1, ie
                         bradi(i+ii-2, j+jj-2, k+kk-2) = radi(i, j, k)
@@ -691,14 +706,54 @@ contains
                      end do
                   end do
                end do
-             end if
+
+               ! need aa and nodal gradients if we have viscous fluxes
+               visc: if (viscous .and. flowRes) then
+
+                  ! speed of sound squared
+                  do k=1, ke
+                     do j=1, je
+                        do i=1, ie
+                           baa(i+ii-2, j+jj-2, k+kk-2) = aa(i, j, k)
+                        end do
+                     end do
+                  end do
+
+                  ! nodal gradients
+                  do k=1, kl
+                     do j=1, jl
+                        do i=1, il
+
+                           bux(i+ii-2, j+jj-2, k+kk-2) = ux(i, j, k)
+                           buy(i+ii-2, j+jj-2, k+kk-2) = uy(i, j, k)
+                           buz(i+ii-2, j+jj-2, k+kk-2) = uz(i, j, k)
+
+                           bvx(i+ii-2, j+jj-2, k+kk-2) = vx(i, j, k)
+                           bvy(i+ii-2, j+jj-2, k+kk-2) = vy(i, j, k)
+                           bvz(i+ii-2, j+jj-2, k+kk-2) = vz(i, j, k)
+
+                           bwx(i+ii-2, j+jj-2, k+kk-2) = wx(i, j, k)
+                           bwy(i+ii-2, j+jj-2, k+kk-2) = wy(i, j, k)
+                           bwz(i+ii-2, j+jj-2, k+kk-2) = wz(i, j, k)
+
+                           bqx(i+ii-2, j+jj-2, k+kk-2) = qx(i, j, k)
+                           bqy(i+ii-2, j+jj-2, k+kk-2) = qy(i, j, k)
+                           bqz(i+ii-2, j+jj-2, k+kk-2) = qz(i, j, k)
+
+                        end do
+                     end do
+                  end do
+               end if visc
+
+             end if intermed
+
           end do
        end do
     end do
     !$OMP END PARALLEL DO
   end subroutine blocketteResCore
 
-  subroutine blockResCore(dissApprox, viscApprox, updateDt, flowRes, turbRes, storeWall, nn, sps)
+  subroutine blockResCore(dissApprox, viscApprox, updateIntermed, flowRes, turbRes, storeWall, nn, sps)
 
     use constants
     use fluxes, only : inviscidCentralFlux_block=>inviscidCentralFlux, &
@@ -721,7 +776,7 @@ contains
 
     implicit none
     ! Input
-    logical, intent(in) :: dissApprox, viscApprox, updateDt, flowRes, turbRes, storeWall
+    logical, intent(in) :: dissApprox, viscApprox, updateIntermed, flowRes, turbRes, storeWall
     integer(kind=intType), intent(in) :: nn, sps
 
     ! Working:
@@ -742,7 +797,7 @@ contains
     end if
 
     ! Compute time step
-    call timestep_block(.not. updateDt)
+    call timestep_block(.not. updateIntermed)
 
     call initres_block(lStart, lEnd, nn, sps) ! Initialize only the Turblent Variables
 

--- a/src/adjoint/masterRoutines.F90
+++ b/src/adjoint/masterRoutines.F90
@@ -1118,7 +1118,7 @@ contains
     ! Working Variables
     integer(kind=intType) :: ierr, mm,i,j,k, l, fSize, ii, jj, iRegion
     real(kind=realType) ::  pLocal
-    logical :: dissApprox, viscApprox, updateDt, flowRes, turbRes, storeWall
+    logical :: dissApprox, viscApprox, updateIntermed, flowRes, turbRes, storeWall
 
     flowRes = .True.
     if (present(useFlowRes)) then
@@ -1146,12 +1146,12 @@ contains
     ! Set the flags:
     dissApprox = lumpedDiss
     viscApprox = lumpedDiss
-    updateDt = .False.
+    updateIntermed = .False.
     storeWall = .True.
     blockettes: if (useBlockettes) then
-       call blocketteResCore(dissApprox, viscApprox, updateDt, flowRes, turbRes, storeWall)
+       call blocketteResCore(dissApprox, viscApprox, updateIntermed, flowRes, turbRes, storeWall)
     else
-       call blockResCore(dissApprox, viscApprox, updateDt, flowRes, turbRes, storeWall, nn, sps)
+       call blockResCore(dissApprox, viscApprox, updateIntermed, flowRes, turbRes, storeWall, nn, sps)
     end if blockettes
     do iRegion=1, nActuatorRegions
        call sourceTerms_block(nn, .True., iRegion, pLocal)


### PR DESCRIPTION
## Purpose

All of the issues explained above is with the option useblockettes:True, which is the default. Regular, non-blockette residual routines do not have these issues.

As mentioned in issue #36, some intermediate variables that are computed during the residual computation are not copied back to main memory when blockettes are used. This may cause issues when reverse AD routines are called with outdated intermediate variables. This PR modifies the blockette code so that when `updateIntermed` flag is `True`, the blockette residual routine updates all the intermediate variables that are needed by the reverse AD routines. The PR also modifies how `blocketteRes` is called from the NKSolver module so that after an ANK or NK step, the intermediate variables are always up to date.

This does not cause issues with the adjoint solver, because the preconditioner matrix is created before any reverse AD call. In the last step inside the preconditioner computations, master routine is called to update every intermediate variable (see: https://github.com/mdolab/adflow/blob/master/src/adjoint/adjointUtils.F90#L592). As a result, the reverse AD calls made for the adjoint solver and RHS computations are done with updated intermediate variables. However, without the master call in the preconditioner routine, they would be out of date, and this can cause issues down the line, for example, if reverse AD routines are called before the preconditioner computation, the results can be inaccurate before this fix.

Previous issue #36 only mentions spectral radii; however, this is not the full set. Copying spectral radii for Euler simulations is good enough, as it was done in PR #37, but this is not enough for viscous simulations. For these cases, we also need to copy out "speed of sound squared" and "nodal gradient" arrays.

This PR also changes the name of the updateDt flag to updateIntermed because this flag is now used to update all intermediate variables in main memory.
Modified matrix-free residual calls in NK solver so that these intermediate variables are not updated there for performance, but they are updated for NK line search calls.

I have ran the same timing tests I did in PR #37. Refer to PR #37 for the explanation of the data provided:

### Old results before this change:

#### 32^3:

Base speed: 0.680003727937
Blockette speed: 1.24622523872
Speedup: 1.8326741273916345

#### 48^3:

Base speed: 0.627221772801
Blockette speed: 1.29751948271
Speedup: 2.068677362578845

### New results with this change:

#### 32^3:

Base speed: 0.67284039047
Blockette speed: 1.09666906157
Speedup:  1.6299096741263446

#### 48^3:

Base speed: 0.624760548343
Blockette speed: 1.13382787755
Speedup: 1.81481990269257


Because now we are copying more data from blockette memory, the performance effect of this modification becomes more pronounced. However, the matrix-free residual calls and the residual calls for the FD based approximate preconditioner do not copy this data out, and therefore they have the same performance as previously. 

Matrix-free operations for the NK solver used to copy out the time step dtl previously, with this PR, I modified them so that the matrix-free operations do not copy these intermediate variables, and therefore, they do not see this performance hit. The residual calls for the line search routines all copy back the intermediate variables now. Furthermore, the getResidual call also updates the intermediate variables.

As a result of these changes, after every ANK or NK step, or after a call to getResidual from python level, all intermediate variables required for the reverse AD routines are up to date, and the reverse AD routines return the exact same result as if we used the non-blockette residual routines.

On top, the matrix-free operations for ANK and NK, along with the FD preconditioner operations do not copy these intermediate variables, and they do not experience this slowdown. These are the part of the main computational cost of ADflow. The overall solution time will not be affected by this change as drastically as the results I posted above.

## Type of change
- Bugfix (non-breaking change which fixes an issue)

## Testing

The issue mentioned in #32 and #36 was incompletely addressed with #37. This is because we only checked Euler cases previously. @sseraj found that if we do a similar test with a RANS case, the AD output is still wrong. This PR addresses the issue found by him. 

To recreate the problem, the similar approach can be followed that was explained in issue #32 but with a laminar NS or a RANS case: 

```
CFDSolver.getResidual(ap)
dwBar = CFDSolver.getStatePerturbation(314)
wbar = CFDSolver.computeJacobianVectorProductBwd(resBar=dwBar, wDeriv=True)
```

The reverse AD routines that are affected are with the seeds for the residuals and AD outputs for the states. Calling the reverse AD routine just with the functionals alone will not recreate this issue. 

I have tested this fix with the test case from @sseraj with Euler, Laminar NS, RANS, and with scalar, matrix, and upwind discretization. 

The regression tests also pass. 

## Checklist

- [x] I have run unit and regression tests which pass locally with my changes
