### PR TITLE
fix call updategamma()

### DIFF
--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -2837,7 +2837,7 @@ class ADFLOW(AeroSolver):
         # Update gamma only if it has changed from what currently is set
         if abs(self.adflow.inputphysics.gammaconstant - gammaConstant) > 1.0e-12:
             self.adflow.inputphysics.gammaconstant = gammaConstant
-            self.adflow.updategamma() # NOTE! It is absolutely necessary to call this function, otherwise gamma is not properly updated.
+            self.adflow.flowutils.updategamma() # NOTE! It is absolutely necessary to call this function, otherwise gamma is not properly updated.
 
         # 4. Periodic Parameters --- These are not checked/verified
         # and come directly from aeroProblem. Make sure you specify


### PR DESCRIPTION
## Purpose
`self.adflow.updategamma()` doesn't exist. It should be `self.adflow.flowutils.updategamma()`

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
ADflow doesn't crash anymore when setting a custom gamma value.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
