### PR TITLE
Updated displacement file handling

### DIFF
--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -413,20 +413,27 @@ class ADFLOW(AeroSolver):
 
     def setDisplacements(self, aeroProblem, dispFile):
         """
-        This function allows the user to perform aerodyanmic
+        This function allows the user to perform aerodynamic
         analysis/optimization while using a fixed set of displacements
         computed from a previous structural analysis. Essentially this
-        allows the jig shape to designed, but performing anlysis on
-        the flying shape. Note that the fixed set of displacements do
-        not affect the sensitivities.
+        allows the jig shape to designed, but performing analysis on
+        the flying shape.
 
         Parameters
         ----------
         aeroProblem : aeroProblem class
            The AP object that the displacements should be applied to.
         dispFile : str
-           The file contaning the displacments. This file should have
+           The file contaning the displacements. This file should have
            been obtained from TACS
+
+        Notes
+        -----
+        The fixed set of displacements do not affect the sensitivities.
+
+        Also, in the case where the current surface mesh was not used
+        to generate the displacements file, a nearest neighbor search
+        is used to apply the displacements.
         """
         self.setAeroProblem(aeroProblem)
 
@@ -446,8 +453,8 @@ class ADFLOW(AeroSolver):
         # Now we need to search each localX in X to find the corresponding D
         try:
             from scipy.spatial import KDTree
-        except:
-            raise Error('scip.spatial must be available to use setDisplacements')
+        except ImportError:
+            raise Error('scipy must be available to use setDisplacements')
         tree = KDTree(numpy.array(X))
         d, index = tree.query(localX)
         for j in range(len(localX)):

--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -429,7 +429,8 @@ class ADFLOW(AeroSolver):
 
         Notes
         -----
-        The fixed set of displacements do not affect the sensitivities.
+        The fixed set of displacements do not affect the sensitivities,
+        since they are fixed and not affected by any DVs.
 
         Also, in the case where the current surface mesh was not used
         to generate the displacements file, a nearest neighbor search

--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -2601,12 +2601,13 @@ class ADFLOW(AeroSolver):
                 self.DVGeo.addPointSet(coords0, ptSetName)
 
             # Check if our point-set is up to date:
-            if not self.DVGeo.pointSetUpToDate(ptSetName):
+            if not self.DVGeo.pointSetUpToDate(ptSetName) or aeroProblem.adflowData.disp is not None:
                 coords = self.DVGeo.update(ptSetName, config=aeroProblem.name)
 
                 # Potentially add a fixed set of displacements to it.
                 if aeroProblem.adflowData.disp is not None:
                     coords += self.curAP.adflowData.disp
+
                 self.setSurfaceCoordinates(coords, self.designFamilyGroup)
 
         self._setAeroProblemData(aeroProblem)


### PR DESCRIPTION
## Purpose
This PR fixes a minor logic in applying displacement files. Now, even if the point sets are up to date, if the displacements are nonzero they are still applied. I also made minor adjustments to the docstrings.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
N/A

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
