### PR TITLE
Fixed OpenMDAO wrapper adjoint gradients.

### DIFF
--- a/adflow/om_func_comp.py
+++ b/adflow/om_func_comp.py
@@ -220,7 +220,7 @@ class OM_FUNC_COMP(ExplicitComponent):
                 # we have to check for 0 here, so we don't include any unnecessary variables in funcsBar
                 # becasue it causes ADflow to do extra work internally even if you give it extra variables, even if the seed is 0
                 if func_name in d_outputs and d_outputs[func_name] != 0.:
-                    funcsBar[func_name] = d_outputs[func_name][0] / self.comm.size
+                    funcsBar[func_name] = d_outputs[func_name][0] 
 
             # because of the 0 checking, the funcsBar is now only correct on the root proc,
             # so we need to broadcast it to everyone. its not actually imporant that the seeds are the same everywhere,

--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -2837,7 +2837,7 @@ class ADFLOW(AeroSolver):
         # Update gamma only if it has changed from what currently is set
         if abs(self.adflow.inputphysics.gammaconstant - gammaConstant) > 1.0e-12:
             self.adflow.inputphysics.gammaconstant = gammaConstant
-            self.adflow.updategamma() # NOTE! It is absolutely necessary to call this function, otherwise gamma is not properly updated.
+            self.adflow.flowutils.updategamma() # NOTE! It is absolutely necessary to call this function, otherwise gamma is not properly updated.
 
         # 4. Periodic Parameters --- These are not checked/verified
         # and come directly from aeroProblem. Make sure you specify


### PR DESCRIPTION
## Purpose
In the OpenMDAO wrapper, the adjoint gradients get divided by the number of procs used. To test it, i ran some gradient computations on a N0012 grid with only alpha as DesignVar:

Type | #Procs | Gradient cd vs alpha | gradient * #Procs
-- | -- | -- | --
Adjoint | 36 | 2.69E-05 | 0.000967035
Adjont | 12 | 8.06E-05 | 0.000967035
Adjoint | 2 | 0.00048352 | 0.00096704
Adjoint | 1 | 0.00096703 | 0.00096703
FD | 36 | 0.00096705 |  
FD | 12 | 0.00096711 |  
FD | 2 | 0.00096705 |  
FD | 1 | 0.00096705 |  



## Type of change
What types of change is it?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
I tested it with the same N0021 setup, but i added the smalest FFD-Box possible to also verify shape variables:

Type | #Procs | Step | Gradient cd vs alpha | Gradient Shape vs alpha |   |   |   |   |   |   |  
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
Adjoint | 12 | - | 0.00096703 | 0.01567259 | 0.01233768 | -0.01110443 | -0.0169077 | 0.01567393 | 0.01233888 | -0.01110383 | -0.01690714
Adjoint | 2 | - | 0.00096703 | 0.01567259 | 0.01233768 | -0.01110443 | -0.0169077 | 0.01567393 | 0.01233888 | -0.01110383 | -0.01690714
Adjoint | 1 | - | 0.00096703 | 0.01567259 | 0.01233768 | -0.01110443 | -0.0169077 | 0.01567393 | 0.01233888 | -0.01110383 | -0.01690714
  |   |   |   |   |   |   |   |   |   |   |  
FFD | 12 | 0.01 | 0.00096803 | 0.01264982 | 0.00981039 | -0.00484323 | -0.01094111 | 0.01929105 | 0.01554729 | -0.01719053 | -0.02236563
FFD | 12 | 0.0001 | 0.00096705 | 0.01239652 | 0.0094796 | -0.00492253 | -0.01096815 | 0.01894803 | 0.01515275 | -0.01750264 | -0.0225605
FFD | 12 | 0.000001 | 0.00096299 | 0.01238968 | 0.00947311 | -0.00492744 | -0.01097548 | 0.01894274 | 0.01514527 | -0.01750633 | -0.02256773
FFD | 1 | 0.000001 | 0.00096566 | 0.01239311 | 0.00947483 | -0.00492816 | -0.01097116 | 0.01894275 | 0.01514771 | -0.01750816 | -0.02256475


There still exists a difference, but it is not depending on the number of procs anymore. Thanks @anilyil for your help with this.

## Checklist

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
