### PR TITLE
self.comm is now set in BaseSolver

### DIFF
--- a/adflow/__init__.py
+++ b/adflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.2.3'
+__version__ = '2.2.4'
 
 from mpi4py import MPI
 

--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -162,8 +162,8 @@ class ADFLOW(AeroSolver):
 
         defSetupTime = time.time()
 
-        AeroSolver.__init__(self, name, category, defOpts, informs,
-                            options=options, comm=comm)
+        AeroSolver.__init__(self, name, category, defaultOptions=defOpts,
+                            options=options, comm=comm, informs=informs)
 
         baseClassTime = time.time()
         # Update turbresscale depending on the turbulence model specified

--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -134,7 +134,7 @@ class ADFLOW(AeroSolver):
         for key in self.basicCostFunctions:
             self.adflowCostFunctions[key] = [None, key]
 
-        # Separate list of the suplied supplied functions
+        # Separate list of the supplied supplied functions
         self.adflowUserCostFunctions = OrderedDict()
 
         # This is the real solver so dtype is 'd'
@@ -144,13 +144,12 @@ class ADFLOW(AeroSolver):
         if comm is None:
             comm = MPI.COMM_WORLD
 
-        self.comm = comm
-        self.adflow.communication.adflow_comm_world = self.comm.py2f()
+        self.adflow.communication.adflow_comm_world = comm.py2f()
         self.adflow.communication.adflow_comm_self = MPI.COMM_SELF.py2f()
-        self.adflow.communication.sendrequests = numpy.zeros(self.comm.size)
-        self.adflow.communication.recvrequests = numpy.zeros(self.comm.size)
-        self.myid = self.adflow.communication.myid = self.comm.rank
-        self.adflow.communication.nproc = self.comm.size
+        self.adflow.communication.sendrequests = numpy.zeros(comm.size)
+        self.adflow.communication.recvrequests = numpy.zeros(comm.size)
+        self.myid = self.adflow.communication.myid = comm.rank
+        self.adflow.communication.nproc = comm.size
 
         # Initialize the inherited aerosolver.
         if options is None:
@@ -164,7 +163,7 @@ class ADFLOW(AeroSolver):
         defSetupTime = time.time()
 
         AeroSolver.__init__(self, name, category, defOpts, informs,
-                            options=options)
+                            options=options, comm=comm)
 
         baseClassTime = time.time()
         # Update turbresscale depending on the turbulence model specified
@@ -181,7 +180,7 @@ class ADFLOW(AeroSolver):
         # terminate calls are handled
         self.adflow.killsignals.frompython = True
 
-        # Dictionary of design varibales and their index
+        # Dictionary of design variables and their index
         self.aeroDVs = []
 
         # Default counters

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name='adflow',
       },
       install_requires=[
             'numpy>=1.16',
-            'mdolab-baseclasses>=1.2',
+            'mdolab-baseclasses>=1.3',
             'mpi4py>=3.0',
             'petsc4py>=3.11',
 


### PR DESCRIPTION
## Purpose
With recent addition of self.comm to BaseSolver in baseclasses (see mdolab/baseclasses#29) self.comm will is overwritten.
However, PR mdolab/baseclasses#30 now adds self.comm as an argument to BaseSolver making it clear to the user where self.comm is set and less error-prone.
This PR adjusts the code to the above changes.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
