### PR TITLE
Minor change to setOption

### DIFF
--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -4322,9 +4322,8 @@ class ADFLOW(AeroSolver):
         """
         Set Solver Option Value
         """
-        name = name.lower()
-
         super().setOption(name, value)
+        name = name.lower()
 
         # If the option is only used in Python, we just return
         if name in self.pythonOptions:


### PR DESCRIPTION
## Purpose
This is a minor change to setOption where casting to lower happens _after_ calling `super().setOption`. This ensures that the options set in baseclasses have the correct capitalization, e.g. for `printModifiedOptions`.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
All existing tests pass.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
