### PR TITLE
Only print modified options when switching ap

### DIFF
--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -32,7 +32,6 @@ from petsc4py import PETSc
 from baseclasses import AeroSolver, AeroProblem, getPy3SafeString
 from baseclasses.utils import Error
 from . import MExt
-from pprint import pprint as pp
 import hashlib
 from collections import OrderedDict
 

--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -915,10 +915,6 @@ class ADFLOW(AeroSolver):
         # Set filenames for possible forced write during solution
         self._setForcedFileNames()
 
-        # Remind the users of the modified options:
-        if self.getOption('printIterations'):
-            self.printModifiedOptions()
-
         # Possibly release adjoint memory if not already done
         # so. Don't remove this. If switching problems, this is done
         # in setAeroProblem, but for when not switching it must be
@@ -2546,10 +2542,12 @@ class ADFLOW(AeroSolver):
         # Tell the user if we are switching aeroProblems
         if self.curAP != aeroProblem:
             newAP = True
-            if self.comm.rank == 0:
-                print('+'+'-'*70+'+')
-                print('|  Switching to Aero Problem: %-41s|'% aeroProblem.name)
-                print('+'+'-'*70+'+')
+            self.pp('+'+'-'*70+'+')
+            self.pp('|  Switching to Aero Problem: %-41s|'% aeroProblem.name)
+            self.pp('+'+'-'*70+'+')
+            # Remind the user of the modified options when switching ap
+            if self.getOption('printIterations'):
+                self.printModifiedOptions()
 
         # See if the aeroProblem has adflowData already, if not, create.
         try:


### PR DESCRIPTION
## Purpose
Previously, the modified options were printed on every `__call__`, which is excessive. Now, they are printed only when switching aero problems, since it's possible for a solver to use different options based on aero problems.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
This works locally.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
