### PR TITLE
Removing CGNS support for versions older than 3.3.0

### DIFF
--- a/config/defaults/config.LINUX_GFORTRAN.mk
+++ b/config/defaults/config.LINUX_GFORTRAN.mk
@@ -20,15 +20,9 @@ CC_INTEGER_PRECISION_FLAG   =
 CC_REAL_PRECISION_FLAG      =
 
 # ------- Define CGNS Inlcude and linker flags -------------------------
-# Define the CNGS include directory and linking flags for CGNSlib. We
-# can use 3.2.x OR CGNS 3.3+. You must define which version is being
-# employed as shown below. We are assuming that HDF5 came from PETSc
-# so it is included in ${PETSC_LIB}. Otherwise you will have to
-# specify the HDF5 library.
-
-# ----------- CGNS ------------------
-# CGNS_VERSION_FLAG=               # for CGNS 3.2.x
-CGNS_VERSION_FLAG=-DUSECGNSMODULE  # for CGNS 3.3.x
+# Define the CGNS include directory and linking flags for the CGNS library.
+# We are assuming that HDF5 came from PETSc so it is included in ${PETSC_LIB}.
+# Otherwise you will have to specify the HDF5 library.
 CGNS_INCLUDE_FLAGS=-I$(CGNS_HOME)/include
 CGNS_LINKER_FLAGS=-L$(CGNS_HOME)/lib -lcgns
 
@@ -49,7 +43,6 @@ include ${PETSC_DIR}/lib/petsc/conf/variables # PETSc 3.6
 PETSC_INCLUDE_FLAGS=${PETSC_CC_INCLUDES} -I$(PETSC_DIR)
 PETSC_LINKER_FLAGS=${PETSC_LIB}
 
-# Combine flags from above -- don't modify here
 # Combine flags from above -- don't modify here
 FF90_PRECISION_FLAGS = $(FF90_INTEGER_PRECISION_FLAG)$(FF90_REAL_PRECISION_FLAG)
 CC_PRECISION_FLAGS   = $(CC_INTEGER_PRECISION_FLAG) $(CC_REAL_PRECISION_FLAG)

--- a/config/defaults/config.LINUX_INTEL.mk
+++ b/config/defaults/config.LINUX_INTEL.mk
@@ -20,15 +20,9 @@ CC_INTEGER_PRECISION_FLAG   =
 CC_REAL_PRECISION_FLAG      =
 
 # ------- Define CGNS Inlcude and linker flags -------------------------
-# Define the CNGS include directory and linking flags for CGNSlib. We
-# can use 3.2.x OR CGNS 3.3+. You must define which version is being
-# employed as shown below. We are assuming that HDF5 came from PETSc
-# so it is included in ${PETSC_LIB}. Otherwise you will have to
-# specify the HDF5 library.
-
-# ----------- CGNS ------------------
-# CGNS_VERSION_FLAG=               # for CGNS 3.2.x
-CGNS_VERSION_FLAG=-DUSECGNSMODULE  # for CGNS 3.3.x
+# Define the CGNS include directory and linking flags for the CGNS library.
+# We are assuming that HDF5 came from PETSc so it is included in ${PETSC_LIB}.
+# Otherwise you will have to specify the HDF5 library.
 CGNS_INCLUDE_FLAGS=-I$(CGNS_HOME)/include
 CGNS_LINKER_FLAGS=-L$(CGNS_HOME)/lib -lcgns
 

--- a/config/defaults/config.LINUX_INTEL_SAFE.mk
+++ b/config/defaults/config.LINUX_INTEL_SAFE.mk
@@ -24,15 +24,9 @@ CC_INTEGER_PRECISION_FLAG   =
 CC_REAL_PRECISION_FLAG      =
 
 # ------- Define CGNS Inlcude and linker flags -------------------------
-# Define the CNGS include directory and linking flags for CGNSlib. We
-# can use 3.2.x OR CGNS 3.3+. You must define which version is being
-# employed as shown below. We are assuming that HDF5 came from PETSc
-# so it is included in ${PETSC_LIB}. Otherwise you will have to
-# specify the HDF5 library.
-
-# ----------- CGNS ------------------
-# CGNS_VERSION_FLAG=               # for CGNS 3.2.x
-CGNS_VERSION_FLAG=-DUSECGNSMODULE  # for CGNS 3.3.x
+# Define the CGNS include directory and linking flags for the CGNS library.
+# We are assuming that HDF5 came from PETSc so it is included in ${PETSC_LIB}.
+# Otherwise you will have to specify the HDF5 library.
 CGNS_INCLUDE_FLAGS=-I$(CGNS_HOME)/include
 CGNS_LINKER_FLAGS=-L$(CGNS_HOME)/lib -lcgns
 

--- a/config/defaults/config.OSX_GFORTRAN.mk
+++ b/config/defaults/config.OSX_GFORTRAN.mk
@@ -23,15 +23,9 @@ CC_INTEGER_PRECISION_FLAG   =
 CC_REAL_PRECISION_FLAG      =
 
 # ------- Define CGNS Inlcude and linker flags -------------------------
-# Define the CNGS include directory and linking flags for CGNSlib. We
-# can use 3.2.x OR CGNS 3.3+. You must define which version is being
-# employed as shown below. We are assuming that HDF5 came from PETSc
-# so it is included in ${PETSC_LIB}. Otherwise you will have to
-# specify the HDF5 library.
-
-# ----------- CGNS ------------------
-# CGNS_VERSION_FLAG=               # for CGNS 3.2.x
-CGNS_VERSION_FLAG=-DUSECGNSMODULE  # for CGNS 3.3.x
+# Define the CGNS include directory and linking flags for the CGNS library.
+# We are assuming that HDF5 came from PETSc so it is included in ${PETSC_LIB}.
+# Otherwise you will have to specify the HDF5 library.
 CGNS_INCLUDE_FLAGS=-I$(CGNS_HOME)/include
 CGNS_LINKER_FLAGS=-L$(CGNS_HOME)/lib -lcgns
 

--- a/src/build/Makefile
+++ b/src/build/Makefile
@@ -3,8 +3,7 @@ include ../../config/config.mk
 
 # Group all the fortran, C and compiler flags together.
 FF90_ALL_FLAGS   = $(FF90_FLAGS) $(CGNS_INCLUDE_FLAGS) -I. \
-		   $(PETSC_CC_INCLUDES) $(FF90_PRECISION_FLAGS) \
-		   $(CGNS_VERSION_FLAG)
+		   $(PETSC_CC_INCLUDES) $(FF90_PRECISION_FLAGS)
 
 CC_ALL_FLAGS     = $(C_FLAGS) -I../c_defines  -I../metis-4.0  $(PETSC_CC_INCLUDES) \
 		   $(CC_PRECISION_FLAGS)

--- a/src/modules/su_cgns.F90
+++ b/src/modules/su_cgns.F90
@@ -1,7 +1,7 @@
        module su_cgns
 !
 !       Module that contains the definition of the cgns parameters.
-!       Depending on the compiler flags either the file cgnslib_f.h is
+!       Depending on the compiler flags either the cgns module is
 !       included or the functionality is faked by just defining the
 !       parameters.
 !
@@ -42,15 +42,9 @@
        integer, parameter :: Radian = 3
 #else
 
-#ifdef USECGNSMODULE
        use cgns
        implicit none
-#else
-       implicit none
-       include "cgnslib_f.h"
-       integer(kind=4), private :: dummyInt
-       integer, parameter :: cgsize_t=kind(dummyInt)
-#endif
+
 #endif
 
 

--- a/src_cs/build/Makefile
+++ b/src_cs/build/Makefile
@@ -3,8 +3,7 @@ include ../../config/config.mk
 
 # Group all the fortran, C and compiler flags together.
 FF90_ALL_FLAGS   = $(FF90_FLAGS) $(CGNS_INCLUDE_FLAGS) -I. -DUSE_COMPLEX \
-		   $(PETSC_CC_INCLUDES) $(FF90_PRECISION_FLAGS) \
-		   $(CGNS_VERSION_FLAG)
+		   $(PETSC_CC_INCLUDES) $(FF90_PRECISION_FLAGS)
 
 CC_ALL_FLAGS     = $(C_FLAGS) -I../c_defines  -I../metis-4.0  $(PETSC_CC_INCLUDES) \
 		   $(CC_PRECISION_FLAGS)


### PR DESCRIPTION
## Purpose
This PR removes support for the old CGNS 3.2.1 library. The code will now only support a proper fortran module. Related to this we are updating our `latest` testing images to use CGNS 4.1.2. Once merged our images test for versions 3.3.0 and 4.1.2. Users still on 3.2.1 will thus need to upgrade.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
Testing was performed both locally and on `u20-gcc-ompi-latest`.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
