### PR TITLE
Fixed MExt

### DIFF
--- a/adflow/MExt.py
+++ b/adflow/MExt.py
@@ -1,5 +1,5 @@
 import tempfile
-import importlib
+from importlib.util import find_spec
 from pathlib import Path
 import os
 import shutil
@@ -15,7 +15,7 @@ def _tmp_pkg(tempDir):
     while True:
         path = tempfile.mkdtemp(dir=tempDir)
         name = os.path.basename(path)
-        spec = importlib.util.find_spec(name)
+        spec = find_spec(name)
         # None means the name was not found
         if spec is None:
             break
@@ -36,7 +36,7 @@ class MExt(object):
         self.name = libName
         self.debug = debug
         # first find the "real" module on the "real" syspath
-        spec = importlib.util.find_spec(packageName)
+        spec = find_spec(packageName)
         srcpath = os.path.join(spec.submodule_search_locations[0], f"{libName}.so")
         # now create a temp directory for the bogus package
         self._pkgname, self._pkgdir = _tmp_pkg(tmpdir)

--- a/adflow/MExt.py
+++ b/adflow/MExt.py
@@ -1,27 +1,28 @@
 import tempfile
-import imp
+import importlib
+from pathlib import Path
 import os
 import shutil
 import sys
 
 
-def _tmp_pkg(dir):
+def _tmp_pkg(tempDir):
     """
     Create a temporary package.
 
     Returns (name, path)
     """
     while True:
-        path = tempfile.mkdtemp(dir=dir)
+        path = tempfile.mkdtemp(dir=tempDir)
         name = os.path.basename(path)
-        try:
-            imp.find_module(name)
-            # if name is found, delete and try again
-            os.rmdir(path)
-        except ImportError:
+        spec = importlib.util.find_spec(name)
+        # None means the name was not found
+        if spec is None:
             break
-    init = open(os.path.join(path, "__init__.py"), "w")
-    init.close()
+        # if name is found, delete and try again
+        os.rmdir(path)
+    # this creates an init file so that python recognizes this as a package
+    Path(os.path.join(path, "__init__.py")).touch()
     return name, path
 
 
@@ -30,12 +31,13 @@ class MExt(object):
     Load a unique copy of a module that can be treated as a "class instance".
     """
 
-    def __init__(self, name, path=None, debug=False):
+    def __init__(self, libName, packageName, debug=False):
         tmpdir = tempfile.gettempdir()
-        self.name = name
+        self.name = libName
         self.debug = debug
         # first find the "real" module on the "real" syspath
-        srcfile, srcpath, srcdesc = imp.find_module(name, path)
+        spec = importlib.util.find_spec(packageName)
+        srcpath = os.path.join(spec.submodule_search_locations[0], f"{libName}.so")
         # now create a temp directory for the bogus package
         self._pkgname, self._pkgdir = _tmp_pkg(tmpdir)
         # copy the original module to the new package
@@ -57,12 +59,7 @@ class MExt(object):
         if not self.debug:
             del sys.modules[self._module.__name__]
             del sys.modules[self._pkg.__name__]
-            # on win32, the DLL must be unloaded forcefully in order to delete it.
-            # on Darwin (other unix???) this doesn't appear to be necessary
-            # try to unload the dll
-            # if os.name == "nt":
-            #     hModule = win32api.GetModuleHandle(self._module.__file__)
-            #     win32api.FreeLibrary(hModule)
+
             # now try to delete the files and directory
             shutil.rmtree(self._pkgdir)
             # make sure the original module is loaded -

--- a/adflow/checkZipper.py
+++ b/adflow/checkZipper.py
@@ -16,8 +16,8 @@ def checkZipper(fileName, options={}):
     """Run the zipper code on the supplied zipper debug file"""
 
     # Import the adflow module, we won't be useing much of it
-    curDir = os.path.dirname(os.path.realpath(__file__))
-    adflow = MExt.MExt("libadflow", [curDir], debug=True)._module
+    curDir = os.path.basename(os.path.dirname(os.path.realpath(__file__)))
+    adflow = MExt.MExt("libadflow", curDir, debug=True)._module
 
     # There is only 1 zipper-specific option
     adflow.inputoverset.selfzipcutoff = options.pop("selfZipCutoff", 120.0)

--- a/adflow/oversetCheck.py
+++ b/adflow/oversetCheck.py
@@ -47,8 +47,8 @@ class OversetCheck(ADFLOW):
 
         # Load the compiled module using MExt, allowing multiple
         # imports
-        curDir = os.path.dirname(os.path.realpath(__file__))
-        self.adflow = MExt.MExt("libadflow", [curDir], debug=debug)._module
+        curDir = os.path.basename(os.path.dirname(os.path.realpath(__file__)))
+        self.adflow = MExt.MExt("libadflow", curDir, debug=debug)._module
 
         # Information for base class:
         name = "ADFLOW"

--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -87,8 +87,8 @@ class ADFLOW(AeroSolver):
         try:
             self.adflow
         except AttributeError:
-            curDir = os.path.dirname(os.path.realpath(__file__))
-            self.adflow = MExt.MExt("libadflow", [curDir], debug=debug)._module
+            curDir = os.path.basename(os.path.dirname(os.path.realpath(__file__)))
+            self.adflow = MExt.MExt("libadflow", curDir, debug=debug)._module
 
         libLoadTime = time.time()
 

--- a/adflow/pyADflow_C.py
+++ b/adflow/pyADflow_C.py
@@ -37,8 +37,8 @@ class ADFLOW_C(ADFLOW):
         if "debug" in kwargs:
             debug = True
 
-        curDir = os.path.dirname(os.path.realpath(__file__))
-        self.adflow = MExt.MExt("libadflow_cs", [curDir], debug=debug)._module
+        curDir = os.path.basename(os.path.dirname(os.path.realpath(__file__)))
+        self.adflow = MExt.MExt("libadflow_cs", curDir, debug=debug)._module
         ADFLOW.__init__(self, dtype="D", *args, **kwargs)
 
     def _on_setOption(self, name, value):


### PR DESCRIPTION
## Purpose
Previously `MExt` used to raise a lot of resource warnings regarding unclosed files. This PR fixes it by switching from `imp` to `importlib` since the former is deprecated. I also made some other minor adjustments to the code to improve readability/code quality.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Code that runs ADflow will not receive `ResourceWarning` anymore.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
