### PR TITLE
Updated mesh unit warning

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -6,7 +6,9 @@ Tutorial
 Meshing
 -------
 
-Before running ADflow we need a CGNS mesh. For a complete tutorial on using MACH, including meshing, please refer to the `MACH aero tutorial <https://github.com/mdolab/MACH_Aero_Tutorials>`_.
+Before running ADflow we need a CGNS mesh.
+The mesh must be in meters.
+For a complete tutorial on using MACH, including meshing, please refer to the :ref:`MACH-Aero tutorial <mach-aero:mach-aero-tutorial-intro>`.
 
 
 Basic Run Script

--- a/src/partitioning/readCGNSGrid.F90
+++ b/src/partitioning/readCGNSGrid.F90
@@ -255,10 +255,7 @@ contains
 
           print "(a)", "#"
           print "(a)", "#                      Warning"
-          print "(a)", "# Conversion factor from grid units to &
-               &meter not specified and some blocks"
-          print "(a)", "# do not have units. It is assumed that &
-               &the grid is given in meters."
+          print "(a)", "# It is assumed that the grid is given in meters."
           print "(a)", "#"
 
        endif


### PR DESCRIPTION
## Purpose
As Sandy explained today, the mesh unit conversion factor was originally in SUmb, but ADflow should only be used with meshes in meters. I updated the mesh unit warning and also added a line in the docs.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
