### PR TITLE
Fixed option printing when using solverOptions

### DIFF
--- a/adflow/__init__.py
+++ b/adflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.5.1"
+__version__ = "2.5.2"
 
 from mpi4py import MPI
 

--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -2647,9 +2647,6 @@ class ADFLOW(AeroSolver):
             self.pp("+" + "-" * 70 + "+")
             self.pp("|  Switching to Aero Problem: %-41s|" % aeroProblem.name)
             self.pp("+" + "-" * 70 + "+")
-            # Remind the user of the modified options when switching ap
-            if self.getOption("printIterations"):
-                self.printModifiedOptions()
 
         # See if the aeroProblem has adflowData already, if not, create.
         try:
@@ -2702,6 +2699,10 @@ class ADFLOW(AeroSolver):
                 self.setSurfaceCoordinates(coords, self.designFamilyGroup)
 
         self._setAeroProblemData(aeroProblem)
+
+        # Remind the user of the modified options when switching AP
+        if newAP and self.getOption("printIterations"):
+            self.printModifiedOptions()
 
         # Reset the fail flags here since the updateGeometry info
         # updates the mesh which may result in a fatalFail.


### PR DESCRIPTION
## Purpose

Since the changes in #116, the modified options are printed immediately after switching to a new AeroProblem. However, these options can change later in `setAeroProblem` if you specify `solverOptions` in `AeroProblem`. I moved the print call to be after the call to `_setAeroProblemData` so that the finalized options are printed.

I also bumped the patch version because we have a few fixes now since the last release. I will make a new release once this is merged.
## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
