### PR TITLE
Number the failed mesh output

### DIFF
--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -173,6 +173,7 @@ class ADFLOW(AeroSolver):
         self.updateTime = 0.0
         self.nSlice = 0
         self.nLiftDist = 0
+        self.nMeshFail = 0
 
         # Set default values
         self.adflow.inputio.autoparameterupdate = False
@@ -1040,14 +1041,15 @@ class ADFLOW(AeroSolver):
                 )
 
         if self.adflow.killsignals.fatalfail:
-            print("Fatal failure during mesh warp! Bad mesh is " "written in output directory as failed_mesh.cgns")
-            fileName = os.path.join(self.getOption("outputDirectory"), "failed_mesh.cgns")
-            self.writeMeshFile(fileName)
+            fileName = f"failed_mesh_{self.nMeshFail:02}.cgns"
+            print(f"Fatal failure during mesh warp! Bad mesh is written in output directory as {fileName}")
+            self.writeMeshFile(os.path.join(self.getOption("outputDirectory"), fileName))
+            self.nMeshFail += 1
             self.curAP.fatalFail = True
             self.curAP.solveFailed = True
             return
 
-        # We now now the mesh warping was ok so reset the flags:
+        # We now know the mesh warping was ok so reset the flags:
         self.adflow.killsignals.routinefailed = False
         self.adflow.killsignals.fatalfail = False
         sys.stdout.flush()


### PR DESCRIPTION
## Purpose
This PR adds numbering to `failed_mesh.cgns` so that multiple failed meshes can be written out without overwriting the previous one.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
I verified this on Great Lakes and it works as expected.

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
