### PR TITLE
removed extra ksp monitor when outerpreconits > 1

### DIFF
--- a/src/adjoint/adjointUtils.F90
+++ b/src/adjoint/adjointUtils.F90
@@ -1455,10 +1455,6 @@ contains
        call KSPSetType(master_PC_KSP, 'richardson', ierr)
        call EChk(ierr, __FILE__, __LINE__)
 
-       call KSPMonitorSet(master_PC_KSP, MyKSPMonitor, PETSC_NULL_FUNCTION, &
-            PETSC_NULL_FUNCTION, ierr)
-       call EChk(ierr, __FILE__, __LINE__)
-
        ! Important to set the norm-type to None for efficiency.
        call kspsetnormtype(master_PC_KSP, KSP_NORM_NONE, ierr)
        call EChk(ierr, __FILE__, __LINE__)


### PR DESCRIPTION
## Purpose
@sseraj and I figured out that PETSc 3.15 somehow messes with the KSP monitor, and turns on a monitor when we have more than one global preconditioner iteration. As we never monitored that before, and the code is currently printing a bunch of zeros, we opted to remove it. 
Closes #154  , and additionally fixes a bug for complexified ADflow. Running complex NK with `nkouterpreconits` >1 leads to a type error in the monitor printout and an instant failure of the run. No monitor, no issue!

I tested both ADflow and pyAerostructure runs and I see no issue, but please verify that this small fix does not remove any relevant monitor feature.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
set `nkouterpreconits:2` and verify how this fix removes the extra `KSP` residual printouts

## Checklist

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
