### PR TITLE
fixed output ranges for split visc subfaces

### DIFF
--- a/src/output/outputMod.F90
+++ b/src/output/outputMod.F90
@@ -1372,8 +1372,9 @@ contains
   end subroutine storeSolInBuffer
 
   subroutine storeSurfsolInBuffer(sps, buffer, nn, blockID,   &
-       faceID, cellRange, solName, &
-       viscousSubface, useRindLayer)
+                                  faceID, cellRange, solName, &
+                                  viscousSubface, useRindLayer, &
+                                  iBeg, iEnd, jBeg, jEnd)
     !
     !       storeSurfsolInBuffer stores the variable indicated by
     !       solName of the given block ID in the buffer. As the solution
@@ -1403,11 +1404,15 @@ contains
     real(kind=realType), dimension(*), intent(out) :: buffer
     character(len=*), intent(in) :: solName
     logical, intent(in) :: viscousSubface, useRindLayer
+    
+    ! if useRindLayer is true, then iBeg, iEnd, jBeg, jEnd are use to determine 
+    ! when the indices are in the rind layer.
+    integer(kind=intType), optional, intent(in) :: iBeg, iEnd, jBeg, jEnd
     !
     !      Local variables.
     !
-    integer(kind=intType) :: i, j, k
-    integer(kind=intType) :: ii, jj, mm, iiMax, jjMax, offVis
+    integer(kind=intType) :: i, j, k, ior, jor
+    integer(kind=intType) :: ii, jj, mm, iiMax, jjMax
 
     integer(kind=intType), dimension(2,2) :: rangeFace
     integer(kind=intType), dimension(3,2) :: rangeCell
@@ -1440,8 +1445,6 @@ contains
     ! friction, need gradIent information, which is not available
     ! in the halo's.
 
-    offVis = 0
-    if(  useRindLayer ) offVis = 1
 
     ! CellRange contains the range of the current block in the
     ! original cgns block. Substract the offset and store the local
@@ -1881,25 +1884,42 @@ contains
        ! only present in the owned faces, the values of the halo's
        ! are set equal to the nearest physical face. Therefore the
        ! working indices are ii and jj.
-
        do j=rangeFace(2,1), rangeFace(2,2)
-          if(j == rangeFace(2,1)) then
-             jj = min(j + offVis, rangeFace(2,2))
-          else if(j == rangeFace(2,2)) then
-             jj = max(j - offVis, rangeFace(2, 1))
-          else
-             jj = j
-          endif
+
+         !  if satements are used to copy the value of of the interior
+         ! cell since the value isn't defined in the rind ell 
+
+         if (present(jBeg) .and. present(jEnd) .and. (useRindLayer)) then 
+            jor = j + jBegOr - 1
+            if (jor == jBeg) then 
+               jj = j + 1 
+            else if (jor == jEnd) then
+               jj = j - 1
+            else
+               jj = j 
+            endif
+         else
+            jj = j
+
+         end if
 
           do i=rangeFace(1,1), rangeFace(1,2)
-             if(i == rangeFace(1,1)) then
-                ii = min(i + offVis, rangeFace(1,2))
-             else if(i == rangeFace(1,2)) then
-                ii = max(i - offVis, rangeFace(1,1))
-             else
-                ii = i
-             endif
-
+             if (present(iBeg) .and. present( iEnd) .and. (useRindLayer)) then 
+               ior = i + iBegor - 1
+               if (ior == iBeg) then 
+                  ! print *, 'ibeg'
+                  ii = i + 1 
+               else if (ior == iEnd) then
+                  ! print *, 'iend'
+                  ii = i - 1
+               else
+                  ! print *, 'else'
+                  ii = i 
+               endif
+            else
+               ii = i
+            endif
+            
              ! Determine the viscous subface on which this
              ! face is located.
 
@@ -1981,23 +2001,40 @@ contains
        ! are set equal to the nearest physical face. Therefore the
        ! working indices are ii and jj.
        do j=rangeFace(2,1), rangeFace(2,2)
-          if(j == rangeFace(2,1)) then
-             jj = min(j + offVis, rangeFace(2,2))
-          else if(j == rangeFace(2,2)) then
-             jj = max(j - offVis, rangeFace(2, 1))
-          else
-             jj = j
-          endif
+
+         !  if satements are used to copy the value of of the interior
+         ! cell since the value isn't defined in the rind ell 
+
+         if (present(jBeg) .and. present(jEnd) .and. (useRindLayer)) then 
+            jor = j + jBegOr - 1
+            if (jor == jBeg) then 
+               jj = j + 1 
+            else if (jor == jEnd) then
+               jj = j - 1
+            else
+               jj = j 
+            endif
+         else
+            jj = j
+
+         end if
 
           do i=rangeFace(1,1), rangeFace(1,2)
-             if(i == rangeFace(1,1)) then
-                ii = min(i + offVis, rangeFace(1,2))
-             else if(i == rangeFace(1,2)) then
-                ii = max(i - offVis, rangeFace(1,1))
-             else
-                ii = i
-             endif
-
+             if (present(iBeg) .and. present( iEnd) .and. (useRindLayer)) then 
+               ior = i + iBegor - 1
+               if (ior == iBeg) then 
+                  ! print *, 'ibeg'
+                  ii = i + 1 
+               else if (ior == iEnd) then
+                  ! print *, 'iend'
+                  ii = i - 1
+               else
+                  ! print *, 'else'
+                  ii = i 
+               endif
+            else
+               ii = i
+            endif
              ! Determine the viscous subface on which this
              ! face is located.
 

--- a/src/output/writeCGNSSurface.F90
+++ b/src/output/writeCGNSSurface.F90
@@ -1320,7 +1320,8 @@ contains
                call storeSurfsolInBuffer(ind, buffer, jj, ii,       &
                     faceID, cellRange(1,1,kk), &
                     solNames(mm),              &
-                    viscousSubface, storeRindLayer)
+                    viscousSubface, storeRindLayer,&
+                    iBeg, iEnd+1, jBeg, jEnd+1)
             endif
          enddo
 

--- a/tests/unit_tests/test_basics.py
+++ b/tests/unit_tests/test_basics.py
@@ -13,3 +13,6 @@ class BasicTests(unittest.TestCase):
         gridFile = "input_files/mdo_tutorial_euler.cgns"
         options = {"gridfile": os.path.join(baseDir, "../../", gridFile)}
         ADFLOW(options=options, debug=False)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Purpose
The goal of this PR is to address is issue #157 
See the issue for details on the issue. 
TLDR: when the subfaces of viscous zones were split, the output data was slightly wrong 


## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)

## Testing
For a problem with a surface output dependent on viscSubFace
1.   add the option "partitionLikeNProc": 50(may need to be higher if you have a finer mesh),
2.   try to write a surface solution file
3.   check for bad output or seg fault

## Checklist
_Put an `x` in the boxes that apply._

- [NA] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
