### PR TITLE
added lots of if allocated statements

### DIFF
--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -82,6 +82,10 @@ class ADFLOW(AeroSolver):
 
         startInitTime = time.time()
 
+        # Define the memory allocation flags ASAP (needed for __del__)
+        # Matrix Setup Flag
+        self.adjointSetup = False
+
         # Load the compiled module using MExt, allowing multiple
         # imports
         try:
@@ -186,9 +190,6 @@ class ADFLOW(AeroSolver):
         self.zipperCreated = False
         self.userSurfaceIntegrationsFinalized = False
         self.hasIntegrationSurfaces = False
-
-        # Matrix Setup Flag
-        self.adjointSetup = False
 
         # Write the intro message
         self.adflow.utils.writeintromessage()

--- a/src/inputParam/inputParamRoutines.F90
+++ b/src/inputParam/inputParamRoutines.F90
@@ -3723,7 +3723,7 @@ contains
     use iteration, only : nOldSolAvail, timeSpectralGridsNotWritten
     use monitor, only : monMassSliding, nTimeStepsRestart, timeUnsteadyRestart
     use killSignals, only : fatalFail, routineFailed
-    use ADjointPETSc, only : adjointPETScVarsAllocated
+    use ADjointPETSc, only : adjointPETScVarsAllocated, adjointPETScPreProcVarsAllocated
     use inputCostFunctions
     implicit none
 
@@ -4041,6 +4041,7 @@ contains
     useApproxWallDistance = .False.
     cflLimit = 3.0
     adjointPETScVarsAllocated = .False.
+    adjointPETScPreProcVarsAllocated = .False.
     usematrixfreedrdw = .False.
     sepSensorOffset = zero
     sepSensorSharpness = 10_realType

--- a/src/modules/ADjointPETSc.F90
+++ b/src/modules/ADjointPETSc.F90
@@ -12,6 +12,8 @@ module ADjointPETSc
 
   ! These are empty vectors
   Vec     w_like1, w_like2, psi_like1, psi_like2, psi_like3, x_like
+  ! This logical is used to indicate whether the vectors have been created
+  logical :: adjointPETScPreProcVarsAllocated
   PetscErrorCode PETScIerr
   PetscFortranAddr   matfreectx(1)
 

--- a/src/preprocessing/preprocessingAPI.F90
+++ b/src/preprocessing/preprocessingAPI.F90
@@ -3967,7 +3967,7 @@ contains
     use inputTimeSpectral, only : nTimeIntervalsSpectral
     use inputAdjoint, only : frozenTurbulence
     use ADjointPETSc, only: w_like1, w_like2, PETScIerr, &
-         psi_like1, psi_like2, x_like, psi_like3
+         psi_like1, psi_like2, x_like, psi_like3, adjointPETScPreProcVarsAllocated
     use utils, only : setPointers, EChk
 #include <petsc/finclude/petsc.h>
     use petsc
@@ -4018,7 +4018,9 @@ contains
     call VecCreateMPIWithArray(ADFLOW_COMM_WORLD,3,ndimX,PETSC_DECIDE, &
          PETSC_NULL_SCALAR,x_like,PETScIerr)
     call EChk(PETScIerr,__FILE__,__LINE__)
-
+    
+    adjointPETScPreProcVarsAllocated = .True.
+    
     ! Need to initialize the stencils as well, only once:
     call initialize_stencils
 

--- a/src/utils/utils.F90
+++ b/src/utils/utils.F90
@@ -4435,31 +4435,57 @@ end subroutine cross_prod
        deallocate(sections)
     end if
 
-    do j=1, size(BCFamExchange, 2)
-       do i=1, size(BCFamExchange, 1)
-          call destroyFamilyExchange(BCFamExchange(i,j))
-       end do
-    end do
-    deallocate(BCFamExchange)
+    if (allocated(BCFamExchange)) then
+      do j=1, size(BCFamExchange, 2)
+         do i=1, size(BCFamExchange, 1)
+            call destroyFamilyExchange(BCFamExchange(i,j))
+         end do
+      end do
+      deallocate(BCFamExchange)
+    end if
+    
+    if (allocated(nCellGlobal)) then
+       deallocate(nCellGlobal)
+    end if
 
-    ! From Communication Stuff
-    do l=1,nLevels
-
-       call deallocateCommType(commPatternCell_1st(l))
-       call deallocateCommType(commPatternCell_2nd(l))
-       call deallocateCommType(commPatternNode_1st(l))
-
-       call deallocateInternalCommType(internalCell_1st(l))
-       call deallocateInternalCommType(internalCell_2nd(l))
-       call deallocateInternalCommType(internalNode_1st(l))
-
-    end do
-    deallocate(nCellGlobal)
-
-    ! Now deallocate the containers
-    deallocate(&
-         commPatternCell_1st, commPatternCell_2nd, commPatternNode_1st, &
-         internalCell_1st, internalCell_2nd, internalNode_1st)
+    
+   ! Now deallocate the containers and communication objects.
+    if (allocated(commPatternCell_1st)) then
+      do l=1,nLevels
+         call deallocateCommType(commPatternCell_1st(l))
+      end do 
+      deallocate(commPatternCell_1st)
+    end if
+    if (allocated(commPatternCell_2nd)) then
+      do l=1,nLevels
+         call deallocateCommType(commPatternCell_2nd(l))
+      end do 
+      deallocate(commPatternCell_2nd)
+    end if
+    if (allocated(commPatternNode_1st)) then
+      do l=1,nLevels
+         call deallocateCommType(commPatternNode_1st(l))
+      end do
+      deallocate(commPatternNode_1st)
+    end if
+    if (allocated(internalCell_1st)) then
+      do l=1,nLevels
+         call deallocateInternalCommType(internalCell_1st(l))
+      end do
+      deallocate(internalCell_1st)
+    end if
+    if (allocated(internalCell_2nd)) then
+      do l=1,nLevels
+         call deallocateInternalCommType(internalCell_2nd(l))
+      end do
+      deallocate(internalCell_2nd)
+    end if
+    if (allocated(internalNode_1st)) then
+      do l=1,nLevels
+         call deallocateInternalCommType(internalNode_1st(l))
+      end do
+      deallocate(internalNode_1st)
+    end if
 
     ! Send/recv buffer
     if (allocated(sendBuffer)) then
@@ -4471,7 +4497,12 @@ end subroutine cross_prod
     end if
 
     ! massFlow stuff from setFamilyInfoFaces.f90
-    deallocate(massFLowFamilyInv, massFlowFamilyDiss)
+    if (allocated(massFlowFamilyInv)) then
+       deallocate(massFlowFamilyInv)
+    end if
+    if (allocated(massFlowFamilyDiss)) then
+       deallocate(massFlowFamilyDiss)
+    end if
 
   end subroutine releaseMemoryPart1
 
@@ -4740,13 +4771,14 @@ end subroutine cross_prod
 
     ! Release the memory of flowDoms of the finest grid and of the
     ! array flowDoms afterwards.
-
-    do sps=1,nTimeIntervalsSpectral
-       do nn=1,nDom
-          call deallocateBlock(nn, 1_intType, sps)
-       enddo
-    enddo
-    deallocate(flowDoms, stat=ierr)
+    if (allocated(flowDoms)) then
+      do sps=1,nTimeIntervalsSpectral
+         do nn=1,nDom
+            call deallocateBlock(nn, 1_intType, sps)
+         enddo
+      enddo
+      deallocate(flowDoms, stat=ierr)
+    end if 
     if(ierr /= 0)                          &
          call terminate("releaseMemoryPart2", &
          "Deallocation failure for flowDoms")
@@ -4755,46 +4787,49 @@ end subroutine cross_prod
     ! be used in combination with adaptation.
 
     ! Destroy variables allocated in preprocessingAdjoint
+    if (adjointPETScPreProcVarsAllocated) then
+      call vecDestroy(w_like1,PETScIerr)
+      call EChk(PETScIerr, __FILE__, __LINE__)
 
-    call vecDestroy(w_like1,PETScIerr)
-    call EChk(PETScIerr, __FILE__, __LINE__)
+      call vecDestroy(w_like2,PETScIerr)
+      call EChk(PETScIerr, __FILE__, __LINE__)
 
-    call vecDestroy(w_like2,PETScIerr)
-    call EChk(PETScIerr, __FILE__, __LINE__)
+      call vecDestroy(psi_like1,PETScIerr)
+      call EChk(PETScIerr, __FILE__, __LINE__)
 
-    call vecDestroy(psi_like1,PETScIerr)
-    call EChk(PETScIerr, __FILE__, __LINE__)
+      call vecDestroy(psi_like2,PETScIerr)
+      call EChk(PETScIerr, __FILE__, __LINE__)
 
-    call vecDestroy(psi_like2,PETScIerr)
-    call EChk(PETScIerr, __FILE__, __LINE__)
+      call vecDestroy(psi_like3,PETScIerr)
+      call EChk(PETScIerr, __FILE__, __LINE__)
 
-    call vecDestroy(psi_like3,PETScIerr)
-    call EChk(PETScIerr, __FILE__, __LINE__)
-
-    call vecDestroy(x_like,PETScIerr)
-    call EChk(PETScIerr, __FILE__, __LINE__)
+      call vecDestroy(x_like,PETScIerr)
+      call EChk(PETScIerr, __FILE__, __LINE__)
+    end if
 
     ! Finally delete cgnsDoms...but there is still more
     ! pointers that need to be deallocated...
-    do nn=1,cgnsNDom
-       if (associated(cgnsDoms(nn)%procStored)) &
-            deallocate(cgnsDoms(nn)%procStored)
+    if (allocated(cgnsDoms)) then
+      do nn=1,cgnsNDom
+         if (associated(cgnsDoms(nn)%procStored)) &
+               deallocate(cgnsDoms(nn)%procStored)
 
-       if (associated(cgnsDoms(nn)%conn1to1)) &
-            deallocate(cgnsDoms(nn)%conn1to1)
+         if (associated(cgnsDoms(nn)%conn1to1)) &
+               deallocate(cgnsDoms(nn)%conn1to1)
 
-       if (associated(cgnsDoms(nn)%connNonMatchAbutting)) &
-            deallocate(cgnsDoms(nn)%connNonMatchAbutting)
+         if (associated(cgnsDoms(nn)%connNonMatchAbutting)) &
+               deallocate(cgnsDoms(nn)%connNonMatchAbutting)
 
-       if (associated(cgnsDoms(nn)%bocoInfo)) &
-            deallocate(cgnsDoms(nn)%bocoInfo)
+         if (associated(cgnsDoms(nn)%bocoInfo)) &
+               deallocate(cgnsDoms(nn)%bocoInfo)
 
-       deallocate(&
-            cgnsDoms(nn)%iBegOr, cgnsDoms(nn)%iEndOr, &
-            cgnsDoms(nn)%jBegOr, cgnsDoms(nn)%jEndOr, &
-            cgnsDoms(nn)%kBegOr, cgnsDoms(nn)%kEndOr, &
-            cgnsDoms(nn)%localBlockID)
-    end do
+         deallocate(&
+               cgnsDoms(nn)%iBegOr, cgnsDoms(nn)%iEndOr, &
+               cgnsDoms(nn)%jBegOr, cgnsDoms(nn)%jEndOr, &
+               cgnsDoms(nn)%kBegOr, cgnsDoms(nn)%kEndOr, &
+               cgnsDoms(nn)%localBlockID)
+      end do
+   end if
 
   end subroutine releaseMemoryPart2
 


### PR DESCRIPTION
## Purpose
If ADflow has an issue in its __init__ it will often try to deallocate variables that haven't been allocated yet. This will usually obscure the original error.  This was particularly annoying for me since I was working on pyAeroProblem, which is used before the preprocessing has been complete.

To solve this I added lots of if (allocated(blah)) statements to prevent it from deallocating variables that don't exist yet. 

Before
```
python test_basics.py
#
# ADflow, multiblock structured flow solver
#
# This code solves the 3D RANS, laminar NS or Euler equations
# on multiblock structured hexahedral grids.
# This is a parallel executable running on 1 processors.
# It has been compiled with the following options:
# - Optimized mode.
# - Size of standard integers: 4 bytes.
# - Size of standard floating point types: 8 bytes.
# - With cgns support
# - With support for signals.
#
-> Alpha... 0.000000 
E[0]PETSC ERROR: ------------------------------------------------------------------------
[0]PETSC ERROR: Caught signal number 11 SEGV: Segmentation Violation, probably memory access out of range
[0]PETSC ERROR: Try option -start_in_debugger or -on_error_attach_debugger
[0]PETSC ERROR: or see http://www.mcs.anl.gov/petsc/documentation/faq.html#valgrind
[0]PETSC ERROR: or try http://valgrind.org on GNU/linux and Apple Mac OS X to find memory corruption errors
[0]PETSC ERROR: likely location of problem given in stack below
[0]PETSC ERROR: ---------------------  Stack Frames ------------------------------------
[0]PETSC ERROR: Note: The EXACT line numbers in the stack are not available,
[0]PETSC ERROR:       INSTEAD the line number of the start of the function
[0]PETSC ERROR:       is given.
--------------------------------------------------------------------------
MPI_ABORT was invoked on rank 0 in communicator MPI_COMM_WORLD
with errorcode 59.

NOTE: invoking MPI_ABORT causes Open MPI to kill all MPI processes.
You may or may not see output from other processes, depending on
exactly when Open MPI kills them.
--------------------------------------------------------------------------
```
or 
```
> python test_basics.py
#
# ADflow, multiblock structured flow solver
#
# This code solves the 3D RANS, laminar NS or Euler equations
# on multiblock structured hexahedral grids.
# This is a parallel executable running on 1 processors.
# It has been compiled with the following options:
# - Optimized mode.
# - Size of standard integers: 4 bytes.
# - Size of standard floating point types: 8 bytes.
# - With cgns support
# - With support for signals.
#
-> Alpha... 0.000000 
E ---------------------------------------------------------------------------
PETSc or MPI Error. Error Code 64. Detected on Proc  0
Error at line:  4794 in file: ../utils/utils.F90
 ---------------------------------------------------------------------------
--------------------------------------------------------------------------
MPI_ABORT was invoked on rank 0 in communicator MPI_COMM_WORLD
with errorcode 64.

NOTE: invoking MPI_ABORT causes Open MPI to kill all MPI processes.
You may or may not see output from other processes, depending on
exactly when Open MPI kills them.
--------------------------------------------------------------------------
```
After 
```
> python test_basics.py
#
# ADflow, multiblock structured flow solver
#
# This code solves the 3D RANS, laminar NS or Euler equations
# on multiblock structured hexahedral grids.
# This is a parallel executable running on 1 processors.
# It has been compiled with the following options:
# - Optimized mode.
# - Size of standard integers: 4 bytes.
# - Size of standard floating point types: 8 bytes.
# - With cgns support
# - With support for signals.
#
+----------------------------------------+
|          All ADFLOW Options:           |
+----------------------------------------+
{....}
-> Alpha... 0.000000 
E
======================================================================
ERROR: test_import (__main__.BasicTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_basics.py", line 15, in test_import
    ADFLOW(options=options, debug=False)
  File "/home/josh/repos/adflow/adflow/pyADflow.py", line 224, in __init__
    self._setAeroProblemData(dummyAP, firstCall=True)
  File "/home/josh/repos/adflow/adflow/pyADflow.py", line 3006, in _setAeroProblemData
    nameArray, dataArray, groupArray, groupNames, empty = self._getBCDataFromAeroProblem(AP)
  File "/home/josh/repos/adflow/adflow/pyADflow.py", line 3023, in _getBCDataFromAeroProblem
    for tmp in AP.bcVarData:
AttributeError: 'AeroProblem' object has no attribute 'bcVarData'

----------------------------------------------------------------------
Ran 1 test in 0.013s

FAILED (errors=1)
```

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
