### PR TITLE
Fixed typo

### DIFF
--- a/src/output/tecplotIO.F90
+++ b/src/output/tecplotIO.F90
@@ -563,7 +563,7 @@ contains
        liftDistNames(12) = "CDp"
        liftDistNames(13) = "CLv"
        liftDistNames(14) = "CDv"
-       liftDistNames(15) = "Ellptical"
+       liftDistNames(15) = "Elliptical"
        liftDistNames(16) = "thickness"
        liftDistNames(17) = "twist"
        liftDistNames(18) = "chord"

--- a/src/overset/oversetUtilities.F90
+++ b/src/overset/oversetUtilities.F90
@@ -2151,7 +2151,7 @@ contains
 
   function checkOversetPresent()
 
-    ! This routine determines if there are any oveset boundaries
+    ! This routine determines if there are any overset boundaries
     ! present in the mesh.
 
     use constants

--- a/src/preprocessing/preprocessingAPI.F90
+++ b/src/preprocessing/preprocessingAPI.F90
@@ -1590,7 +1590,7 @@ contains
           case (iBCGroupFarfield)
              write(*,"(a)",advance="no") '| Farfield Types       : '
           case (iBCGroupOverset)
-             write(*,"(a)",advance="no") '| Oveset Types         : '
+             write(*,"(a)",advance="no") '| Overset Types        : '
           case (iBCGroupOther)
              write(*,"(a)",advance="no") '| Other Types          : '
           end select

--- a/src/utils/haloExchange.F90
+++ b/src/utils/haloExchange.F90
@@ -1429,7 +1429,7 @@ contains
        commVarGamma, commLamVis, commEddyVis, &
        commPattern, internal)
     !
-    !       wOverset_b performs the *TRANSPOSE* operation of wOveset
+    !       wOverset_b performs the *TRANSPOSE* operation of wOverset
     !       It is used for adjoint/reverse mode residual evaluations.
     !      * See wOverset  for more information.
     !


### PR DESCRIPTION
## Purpose
Um, I think all the lift files written in the last however many years have all had this typo... how did this never come up before?

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
