### PR TITLE
Changed printing to use proper scientific notation

### DIFF
--- a/src/adjoint/adjointAPI.F90
+++ b/src/adjoint/adjointAPI.F90
@@ -873,7 +873,7 @@ contains
 
 10  format(a)
 20  format(a,1x,f8.2)
-30  format(1x,a,1x,e10.4,4x,a,1x,i4)
+30  format(1x,a,1x,es10.4,4x,a,1x,i4)
 40  format(1x,a,1x,i5,1x,a)
 
 #endif

--- a/src/adjoint/adjointUtils.F90
+++ b/src/adjoint/adjointUtils.F90
@@ -1348,7 +1348,7 @@ contains
 
     ! Output format.
 
-10  format(i4, 1x, 'KSP Residual norm', 1x, e16.10)
+10  format(i4, 1x, 'KSP Residual norm', 1x, es16.10)
 
   end subroutine MyKSPMonitor
 

--- a/src/bcdata/BCData.F90
+++ b/src/bcdata/BCData.F90
@@ -192,8 +192,8 @@ contains
              print 100, tt, cpTrange(0)
              print "(a)", "# Extrapolation with constant cp is used."
              print "(a)", "#"
-100          format("# Prescribed total temperature ",e12.5,          &
-                  " is less than smallest curve fit value, ",e12.5, &
+100          format("# Prescribed total temperature ",es12.5,          &
+                  " is less than smallest curve fit value, ",es12.5, &
                   ".")
           endif
 
@@ -211,9 +211,9 @@ contains
              print 101, tt, cpTrange(cpNparts)
              print "(a)", "# Extrapolation with constant cp is used."
              print "(a)", "#"
-101          format("# Prescribed total temperature ",e12.5,     &
+101          format("# Prescribed total temperature ",es12.5,     &
                   " is larger than largest curve fit value, ", &
-                  e12.5, ".")
+                  es12.5, ".")
           endif
 
           ht = RGasDim*(cpEint(cpNparts) + tt &

--- a/src/output/outputMod.F90
+++ b/src/output/outputMod.F90
@@ -2723,7 +2723,7 @@ contains
 
        write(integerString,"(i7)") timeStepUnsteady + &
             nTimeStepsRestart
-       write(realString,"(e12.5)") timeUnsteady + &
+       write(realString,"(es12.5)") timeUnsteady + &
             timeUnsteadyRestart
 
        integerString = adjustl(integerString)

--- a/src/output/outputMod.F90
+++ b/src/output/outputMod.F90
@@ -2206,7 +2206,7 @@ contains
 
     end select
 
-100 format(1X, A,", k2 = ", e12.5, ", k4 = ", e12.5,".")
+100 format(1X, A,", k2 = ", es12.5, ", k4 = ", es12.5,".")
 110 format(1X, A)
 111 format(1X, "Second order upwind scheme using linear reconstruction, &
          &i.e. no limiter, kappa =", 1X, f7.3,".")
@@ -2228,7 +2228,7 @@ contains
     endif
 
 200 format(1X, A, 1X, "Directional scaling of dissipation with exponent", &
-         1X,e12.5, ".")
+         1X,es12.5, ".")
 210 format(1X, A, 1X, "No directional scaling of dissipation.")
 
     ! For the Euler equations, write the inviscid wall boundary

--- a/src/output/tecplotIO.F90
+++ b/src/output/tecplotIO.F90
@@ -582,7 +582,7 @@ contains
           write (fileID,"(a,a,a)") "Zone T= """,trim(d%distName),""""
           write (fileID,*) "I= ",d%nSegments
           write (fileID,*) "DATAPACKING=BLOCK"
-15        format (E14.6)
+15        format (ES14.6)
        end if
 
        allocate(values(d%nSegments, nLiftDistVar))
@@ -2093,7 +2093,7 @@ contains
     if (slc%nNodes > 0) then
        write (fileID,*) "Nodes = ", slc%nNodes, " Elements= ",  size(slc%conn, 2), " ZONETYPE=FELINESEG"
        write (fileID,*) "DATAPACKING=POINT"
-13     format (E14.6)
+13     format (ES14.6)
 
        do i=1,slc%nNodes
           ! Write the coordinates

--- a/src/overset/oversetUtilities.F90
+++ b/src/overset/oversetUtilities.F90
@@ -2314,7 +2314,7 @@ contains
                      x(i-1, j  , k  , :) + &
                      x(i  , j  , k  , :))
 
-                write(19, "(E18.10, E18.10, E18.10, I3)") xp(1), xp(2), xp(3), iblank(i, j, k)
+                write(19, "(es18.10, E18.10, E18.10, I3)") xp(1), xp(2), xp(3), iblank(i, j, k)
              end do
           end do
        end do

--- a/src/overset/oversetUtilities.F90
+++ b/src/overset/oversetUtilities.F90
@@ -71,7 +71,7 @@ contains
        do i=1, overlap%nrow
           write(*, "(a,I4, a)", advance='no') 'Row:', i, "   "
           do jj=overlap%rowPtr(i), overlap%rowPtr(i+1)-1
-             write(*, "(a,I2, a, e10.5)", advance='no') "(", overlap%colInd(jj), ")", overlap%data(jj)
+             write(*, "(a,I2, a, es10.5)", advance='no') "(", overlap%colInd(jj), ")", overlap%data(jj)
           end do
           write(*, *) " "
        end do
@@ -2314,7 +2314,7 @@ contains
                      x(i-1, j  , k  , :) + &
                      x(i  , j  , k  , :))
 
-                write(19, "(es18.10, E18.10, E18.10, I3)") xp(1), xp(2), xp(3), iblank(i, j, k)
+                write(19, "(ES18.10, ES18.10, ES18.10, I3)") xp(1), xp(2), xp(3), iblank(i, j, k)
              end do
           end do
        end do

--- a/src/overset/stringOps.F90
+++ b/src/overset/stringOps.F90
@@ -2820,7 +2820,7 @@ module stringOps
 
     write (fileID,*) "Nodes = ", str%nNodes, " Elements= ", str%nElems, " ZONETYPE=FELINESEG"
     write(fileID, *) "DATAPACKING=BLOCK"
-13  format (E20.12)
+13  format (ES20.12)
 
     ! Nodes
     do j=1,3
@@ -2928,7 +2928,7 @@ module stringOps
 
     write (fileID,*) "Nodes = ", str%nNodes, " Elements= ", str%nElems, " ZONETYPE=FELINESEG"
     write(fileID, *) "DATAPACKING=BLOCK"
-13  format (E20.12)
+13  format (ES20.12)
 
     ! Nodes
     do j=1,3
@@ -2965,7 +2965,7 @@ module stringOps
 
     write (101,*) "Nodes = ", string%nNodes, " Elements= ", (endTri-startTri+1), " ZONETYPE=FETRIANGLE"
     write (101,*) "DATAPACKING=POINT"
-13  format (E20.12)
+13  format (ES20.12)
 
     ! Write all the coordinates
     do i=1, string%nNodes

--- a/src/overset/zipperMesh.F90
+++ b/src/overset/zipperMesh.F90
@@ -1420,7 +1420,7 @@ contains
 110     format('ZONE T=',a, " I=", i5, " J=", i5)
         write(101, 110) trim(zoneName), iEnd-iBeg+1, jEnd-jBeg+1
         write (101,*) "DATAPACKING=BLOCK, VARLOCATION=([1,2,3]=NODAL, [4]=CELLCENTERED)"
-13      format (E20.12)
+13      format (ES20.12)
 
         ! The 3 is for the three coordinate directions
         nNode = (iEnd - iBeg + 1)*(jEnd - jBeg + 1)

--- a/src/partitioning/gridChecking.F90
+++ b/src/partitioning/gridChecking.F90
@@ -986,15 +986,15 @@ contains
 104    format("# List of nonmatching one to one subfaces.")
 105    format("# Spectral grid ",a, ", zone ",a, ", periodic &
             &subface ", a, " does not match donor ", a,". &
-            &Maximum deviation: ", e12.5)
+            &Maximum deviation: ", es12.5)
 106    format("# Spectral grid ",a, ", zone ",a, ", subface ", &
             a, " does not match donor ", a,". &
-            &Maximum deviation: ", e12.5)
+            &Maximum deviation: ", es12.5)
 107    format("# Zone ",a, ", periodic subface ", a, " does not &
-            &match donor ", a,". Maximum deviation: ", e12.5)
+            &match donor ", a,". Maximum deviation: ", es12.5)
 
 108    format("# Zone ",a, ", subface ", a, " does not match &
-            &donor ", a,". Maximum deviation: ", e12.5)
+            &donor ", a,". Maximum deviation: ", es12.5)
 
     endif
 

--- a/src/preprocessing/preprocessingAPI.F90
+++ b/src/preprocessing/preprocessingAPI.F90
@@ -3512,8 +3512,8 @@ contains
                                     trim(intString3), &
                                     xc(1), xc(2), xc(3), -vol(i,j,k)
 102                            format("# Indices (",a,",",a,",",a,"), &
-                                    &coordinates (",e10.3,",",e10.3,",", &
-                                    e10.3,"), Volume: ",e10.3)
+                                    &coordinates (",es10.3,",",es10.3,",", &
+                                    es10.3,"), Volume: ",es10.3)
 
                             endif
                          enddo

--- a/src/preprocessing/preprocessingAPI.F90
+++ b/src/preprocessing/preprocessingAPI.F90
@@ -1019,7 +1019,7 @@ contains
 100                   format("# Symmetry boundary face",1X,A,1X,"of zone", &
                            1x,a,1x, "is not planar.")
 110                   format("# Maximum deviation from the mean normal: ", &
-                           e12.5, " degrees")
+                           es12.5, " degrees")
 
                    endif
 

--- a/src/solver/actuatorRegion.F90
+++ b/src/solver/actuatorRegion.F90
@@ -394,7 +394,7 @@ contains
           write (101,*) "Nodes = ", nUnique, " Elements= ", totalCount, " ZONETYPE=FEBRICK"
           write (101,*) "DATAPACKING=BLOCK, VARLOCATION=([1,2,3]=NODAL, [4]=CELLCENTERED)"
 
-13        format (E20.12)
+13        format (ES20.12)
 
           ! Write all the coordinates...this is horrendously slow...
           do iDim=1, 3

--- a/src/solver/solvers.F90
+++ b/src/solver/solvers.F90
@@ -1552,7 +1552,7 @@ contains
 
                 write(*,"(i6,1x)",advance="no") timeStepUnsteady + &
                      nTimeStepsRestart
-                write(*,"(e12.5,1x)",advance="no") timeUnsteady + &
+                write(*,"(es12.5,1x)",advance="no") timeUnsteady + &
                      timeUnsteadyRestart
 
              else if(equationMode == timeSpectral) then
@@ -1571,9 +1571,9 @@ contains
                    write(*,"(a,1x)", advance="no") "    ----  "
                 else
 #ifndef USE_COMPLEX
-                   write(*,"(e10.2,1x)",advance="no") CFLMonitor
+                   write(*,"(es10.2,1x)",advance="no") CFLMonitor
 #else
-                   write(*,"(e10.2,1x)",advance="no") real(CFLMonitor)
+                   write(*,"(es10.2,1x)",advance="no") real(CFLMonitor)
 #endif
                 end if
 
@@ -1602,9 +1602,9 @@ contains
 
                 if( showCPU ) then
 #ifndef USE_COMPLEX
-                   write(*,"(e12.5,1x)",advance="no") mpi_wtime() - t0Solver
+                   write(*,"(es12.5,1x)",advance="no") mpi_wtime() - t0Solver
 #else
-                   write(*,"(e12.5,1x)",advance="no") real(mpi_wtime() - t0Solver)
+                   write(*,"(es12.5,1x)",advance="no") real(mpi_wtime() - t0Solver)
 #endif
                 end if
              end if
@@ -1650,7 +1650,7 @@ contains
           if (myid == 0 .and. printIterations) then
              ! Write the convergence info to stdout.
 #ifndef USE_COMPLEX
-             write(*,"(e24.16,1x)",advance="no") monGlob(mm)
+             write(*,"(es24.16,1x)",advance="no") monGlob(mm)
 #else
             select case (monNames(mm))
 

--- a/src/solver/solvers.F90
+++ b/src/solver/solvers.F90
@@ -995,12 +995,12 @@ contains
 102    format("# Grid",1X,I1,": Performing",1X,A,1X, &
             "iterations, unless converged earlier.",&
             " Minimum required iteration before NK switch: ",&
-            I6,". Switch to NK at totalR of:",1X,e10.2)
+            I6,". Switch to NK at totalR of:",1X,es10.2)
 #else
 102    format("# Grid",1X,I1,": Performing",1X,A,1X, &
             "iterations, unless converged earlier.",&
             " Minimum required iteration before NK switch: ",&
-            I6,". Switch to NK at totalR of:",1X,2e10.2)
+            I6,". Switch to NK at totalR of:",1X,2es10.2)
 #endif
 
        if (printIterations)  then

--- a/src/solver/solvers.F90
+++ b/src/solver/solvers.F90
@@ -1663,11 +1663,11 @@ contains
 
                ! we can do a shorter print for residuals because only the leading few digits
                ! and the exponents are important anyways
-               write(*,'(e16.8,SP,e17.8E3,"i")',advance="no") monGlob(mm)
+               write(*,'(es16.8,SP,es17.8E3,"i")',advance="no") monGlob(mm)
 
             case default
                ! we need to do the regular full print for functionals because they are useful
-               write(*,'(e24.16,SP,e25.16E3,"i")',advance="no") monGlob(mm)
+               write(*,'(es24.16,SP,es25.16E3,"i")',advance="no") monGlob(mm)
             end select
 #endif
           end if

--- a/src/utils/utils.F90
+++ b/src/utils/utils.F90
@@ -6381,7 +6381,7 @@ end subroutine cross_prod
 
     write(integerString,"(i7)") timeStepUnsteady + &
          nTimeStepsRestart
-    write(realString,"(e12.5)") timeUnsteady + &
+    write(realString,"(es12.5)") timeUnsteady + &
          timeUnsteadyRestart
 
     integerString = adjustl(integerString)

--- a/src/wallDistance/wallDistance.F90
+++ b/src/wallDistance/wallDistance.F90
@@ -325,7 +325,7 @@ contains
     !          print "(a)", "#"
     !        endif
 102 format("# End wall distances level",1X,A)
-103 format("# Wall clock time:",E12.5," sec.")
+103 format("# Wall clock time:",ES12.5," sec.")
 
   end subroutine computeWallDistance
 


### PR DESCRIPTION
## Purpose
I changed a lot of the printing that used the format `e.` to use `es.`, so that numbers show up as `4.9E2` instead of `0.49E3`. I was really annoyed with the constant leading zero, so this should make everything more readable.

I used some regex to find these, so I might've missed some stuff. Would appreciate some checking by ADflow maintainers since I'm not as familiar with the code. This may also be a good time to change other printing formats, especially since I noticed we are now showing 16 decimal places which is probably too much.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
I ran the MACH-Aero tutorial and saw that the printing is now using proper scientific notation.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
