### PR TITLE
fixed long compile time on intel compiler

### DIFF
--- a/src/adjoint/adjointDebug.F90
+++ b/src/adjoint/adjointDebug.F90
@@ -285,6 +285,7 @@ contains
 
 
     subroutine printADSeeds(nn, level, sps)
+!DIR$ NOOPTIMIZE
         ! this routine is used for debugging master_d, and master_b.
         ! it prints all the AD seeds used
         ! it is useful to save the output and compare it with a diff tool


### PR DESCRIPTION
## Purpose
Added a compiler directive to  prevent optimization of the `printADSeed` subroutine added in the last PR

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x]  Maintenance update
- [ ] Other (please describe)

## Testing
time the compile time with and without the directive. 
Or look at the compile times in the azure tests

## Checklist

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
