### PR TITLE
Convergence history is now written to the CGNS volume file

### DIFF
--- a/src/f2py/adflow.pyf
+++ b/src/f2py/adflow.pyf
@@ -677,17 +677,17 @@ python module libadflow
                 integer(kind=inttype) dimension(:,:) :: bcdatafamlists
                 logical intent(in) :: bcvarsempty
             end subroutine computematrixfreeproductbwd
-            
-            
+
+
             subroutine computematrixfreeproductbwdfast(dwbar, wbar, statesize)! in :test:adjointapi.f90:adjointapi
                 real(kind=realtype) dimension(:),intent(in) :: dwbar
                 real(kind=realtype) dimension(statesize),intent(out),depend(statesize) :: wbar
                 integer(kind=inttype) intent(in) :: statesize
-            end subroutine computematrixfreeproductbwdfast     
+            end subroutine computematrixfreeproductbwdfast
 #endif
        end module adjointapi
        module adjointdebug
-        
+
 #ifndef USE_COMPLEX
         subroutine computematrixfreeproductfwdfd(xvdot,extradot,wdot,bcdatavaluesdot,usespatial,usestate,famlists,bcdatanames,bcdatavalues,bcdatafamlists,bcvarsempty,dwdot,funcsdot,fdot,costsize,fsize,ntime,h) ! in :test:adjointAPI.F90:adjointdebug
           real(kind=realtype) dimension(:),intent(in) :: xvdot
@@ -1309,7 +1309,6 @@ python module libadflow
          logical :: showcpu
          logical :: monmasssliding
          logical :: monmassfamilies
-         integer :: nitercur
          real(kind=realtype) allocatable,dimension(:,:,:) :: convarray
          integer(kind=inttype) :: ntimestepsrestart
          integer(kind=inttype) :: timestepunsteady

--- a/src/modules/monitor.f90
+++ b/src/modules/monitor.f90
@@ -65,11 +65,6 @@
 !
 !       Variables to store the convergence info.
 !
-       ! nIterCur: Current number of iterations. Also niterCur is an
-       !           integer, because of cgns.
-
-       integer :: nIterCur
-
        ! convArray(0:nIterMax,nsps,nmon): 3D array to store the
        !                                  convergence histories.
 

--- a/src/output/writeCGNSVolume.F90
+++ b/src/output/writeCGNSVolume.F90
@@ -490,7 +490,8 @@ contains
     !
     use inputIO
     use inputPhysics
-    use monitor
+    use monitor, only : nMon, monNames, convArray
+    use iteration, only : iterTot
     use su_cgns
     use outputMod
     use utils, only : terminate
@@ -510,9 +511,9 @@ contains
     if(.not. storeConvInnerIter) return
 
     ! Store the number of iterations to be written in nn.
-    ! This is nIterCur + 1, because the array starts at 0.
+    ! This is iterTot + 1, because the array starts at 0.
 
-    nn = nIterCur + 1
+    nn = iterTot + 1
 
     ! Depending on the input option, set the CGNS type and allocate
     ! the memory for either buf4 or buf8.
@@ -521,7 +522,7 @@ contains
     ! that's what Tecplot needs
 
     realTypeCGNS = RealDouble
-    allocate(buf8(0:nIterCur), stat=ierr)
+    allocate(buf8(0:iterTot), stat=ierr)
 
 
     if(ierr /= 0)                         &
@@ -585,7 +586,7 @@ contains
 
           ! Copy the convergence info to either buf4 or buf8 and write
           ! it to file.
-          do mm=0,nIterCur
+          do mm=0,iterTot
              buf8(mm) = convArray(mm,conv,i)
           enddo
 

--- a/src/solver/solvers.F90
+++ b/src/solver/solvers.F90
@@ -959,7 +959,7 @@ contains
     nMGCycles = nCycles
     if(groundLevel > 1) nMGCycles = nCyclesCoarse
 
-    ! Allocate (or reallocate) the convergence arry for this solveState.
+    ! Allocate (or reallocate) the convergence array for this solveState.
     call allocConvArrays(nMGCycles)
 
     ! Allocate space for storing hisotry of function evaluations for NK
@@ -1283,7 +1283,7 @@ contains
     ! Determine whether or not the iterations must be written.
 
     writeIterations = .true.
-    if(equationMode          == unsteady .and. &
+    if(equationMode            == unsteady .and. &
          timeIntegrationScheme == explicitRK) writeIterations = .false.
 
     ! Initializations


### PR DESCRIPTION
## Purpose
This PR fixes a regression that happened a long time ago. The solver convergence history is now written properly to the CGNS volume file.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Run any case with `writevolumesolution = True`. Load the resulting CGNS file into Tecplot and,

1. specify "Advanced Options"
2. choose to "Load global convergence history data" when opening
3. check that XY line plot produces the desired output, by setting the appropriate mapping.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
