### PR TITLE
Zipper mesh segfault fix

### DIFF
--- a/src/overset/stringOps.F90
+++ b/src/overset/stringOps.F90
@@ -2571,8 +2571,9 @@ module stringOps
        ! Loop over my nodes and search for it in master tree
        nodeLoop:do j=1, str%nNodes
 
-          ! Reinitialize initial maximum number of neighbours
-          nSearch = 50
+          ! Set the initial maximum number of neighbours
+          ! This can be at most the total number of nodes
+          nSearch = min(nAlloc, master%nNodes)
 
           ! We have to be careful since single-sided chains have only
           ! 1 neighbour at each end.

--- a/tests/reg_tests/test_zipper.py
+++ b/tests/reg_tests/test_zipper.py
@@ -1,0 +1,63 @@
+import unittest
+import os
+import copy
+from adflow import ADFLOW
+from reg_default_options import adflowDefOpts
+from reg_aeroproblems import ap_simple_cart_cube
+
+
+baseDir = os.path.dirname(os.path.abspath(__file__))
+
+# Tests for zipper meshes using a mesh with two overlapping cubes
+
+gridFile = os.path.join(baseDir, "../../input_files/cube_overset.cgns")
+commonTestOptions = {
+    "gridFile": gridFile,
+    "equationType": "RANS",
+    "writeTecplotSurfaceSolution": True,
+    "monitorVariables": ["cpu", "resrho", "resturb", "cd"],
+    "volumeVariables": ["resrho", "resturb", "cp", "mach", "blank"],
+    "mgcycle": "sg",
+    "L2Convergence": 1e-13,
+    "nCycles": 500,
+    "useANKSolver": True,
+    "useNKSolver": True,
+    "nearWallDist": 1.0,
+}
+
+
+class TestCubeOverset(unittest.TestCase):
+    N_PROCS = 2
+
+    def setUp(self):
+
+        super().setUp()
+
+        # Start with the default testing options dictionary
+        options = copy.copy(adflowDefOpts)
+
+        # Set the output directory
+        options["outputDirectory"] = os.path.join(baseDir, options["outputDirectory"])
+
+        # These are the modified options common to these tests
+        options.update(commonTestOptions)
+
+        # Define the AeroProblem
+        self.ap = copy.deepcopy(ap_simple_cart_cube)
+
+        # Create the solver
+        self.CFDSolver = ADFLOW(options=options, debug=False)
+
+    def test_convergence(self):
+
+        # Solve the flow
+        self.CFDSolver(self.ap)
+
+        # Check that the flow converged
+        funcs = {}
+        self.CFDSolver.checkSolutionFailure(self.ap, funcs)
+        self.assertFalse(funcs["fail"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->

This fixes the zipper mesh segfault issue first reported by @awccopp. 

When creating the zipper mesh, indexing out of bounds can occur when the number of closest points we are searching for is greater than the total number of points on a string. Capping the initial `nSearch` in the `stringMatch` routine solves the issue.

The current initial value for `nSearch` is 50, which explains why the problem only appears on small meshes like @awccopp's airfoil cases. I added a test with a simple overset cube mesh that can reproduce the error.


## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
Regular urgency; one week

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

Run test_zipper.py without compiling the fix. The result will be a segfault (or 'index outside of expected range' if compiled with a bounds check flag).
Run the test again after recompiling. The test should now pass.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
