### PR TITLE
Read solution fix for split blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ADflow
-[![Build Status](https://dev.azure.com/mdolab/Public/_apis/build/status/mdolab.adflow?repoName=mdolab%2Fadflow&branchName=master)](https://dev.azure.com/mdolab/Public/_build/latest?definitionId=4&repoName=mdolab%2Fadflow&branchName=master)
+[![Build Status](https://dev.azure.com/mdolab/Public/_apis/build/status/mdolab.adflow?repoName=mdolab%2Fadflow&branchName=main)](https://dev.azure.com/mdolab/Public/_build/latest?definitionId=4&repoName=mdolab%2Fadflow&branchName=main)
 [![Documentation Status](https://readthedocs.com/projects/mdolab-adflow/badge/?version=latest)](https://mdolab-adflow.readthedocs-hosted.com/?badge=latest)
-[![codecov](https://codecov.io/gh/mdolab/adflow/branch/master/graph/badge.svg?token=DRCCCL12I8)](https://codecov.io/gh/mdolab/adflow)
+[![codecov](https://codecov.io/gh/mdolab/adflow/branch/main/graph/badge.svg?token=DRCCCL12I8)](https://codecov.io/gh/mdolab/adflow)
 
 ADflow is a flow solver developed by the MDO Lab at the University of Michigan.
 It solves the compressible Euler, laminar Navier–Stokes and Reynolds-averaged Navier–Stokes equations using structured multi-block and overset meshes.

--- a/src/initFlow/initializeFlow.F90
+++ b/src/initFlow/initializeFlow.F90
@@ -3051,9 +3051,9 @@ end subroutine infChangeCorrection
 
              ! Set the cell range to be read from the CGNS file.
 
-             rangeMin(1) = iBegOr + rindSizes(1) - nHiMin
-             rangeMin(2) = jBegOr + rindSizes(3) - nHjMin
-             rangeMin(3) = kBegOr + rindSizes(5) - nHkMin
+             rangeMin(1) = iBegOr - nHiMin
+             rangeMin(2) = jBegOr - nHjMin
+             rangeMin(3) = kBegOr - nHkMin
 
              rangeMax(1) = rangeMin(1) + nx-1 + nHiMin + nHiMax
              rangeMax(2) = rangeMin(2) + ny-1 + nHjMin + nHjMax
@@ -3068,9 +3068,9 @@ end subroutine infChangeCorrection
 
              halosRead   = .false.
 
-             rangeMin(1) = iBegor + rindSizes(1)
-             rangeMin(2) = jBegor + rindSizes(3)
-             rangeMin(3) = kBegor + rindSizes(5)
+             rangeMin(1) = iBegor
+             rangeMin(2) = jBegor
+             rangeMin(3) = kBegor
 
              rangeMax(1) = rangeMin(1) + nx
              rangeMax(2) = rangeMin(2) + ny

--- a/tests/unit_tests/test_restart.py
+++ b/tests/unit_tests/test_restart.py
@@ -1,0 +1,40 @@
+import unittest
+import os
+from adflow import ADFLOW
+import numpy as np
+import sys
+
+baseDir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(baseDir, "../reg_tests"))
+
+from reg_aeroproblems import ap_tutorial_wing
+
+
+class BasicTests(unittest.TestCase):
+    N_PROCS = 1
+
+    def setUp(self):
+        gridFile = "input_files/mdo_tutorial_euler_scalar_jst.cgns"
+        self.options = {
+            "gridfile": os.path.join(baseDir, "../../", gridFile),
+            "restartFile": os.path.join(baseDir, "../../", gridFile),
+            "MGCycle": "sg",
+            "equationType": "Euler",
+        }
+
+    def test_import(self):
+        CFDSolver = ADFLOW(options=self.options, debug=False)
+        res = CFDSolver.getResidual(ap_tutorial_wing)
+        res_norm = np.linalg.norm(res)
+        np.testing.assert_allclose(res_norm, 0.0, atol=1e-11, err_msg="residual")
+
+    def test_import_block_splitting(self):
+        self.options["partitionLikeNProc"] = 50
+        CFDSolver = ADFLOW(options=self.options, debug=False)
+        res = CFDSolver.getResidual(ap_tutorial_wing)
+        res_norm = np.linalg.norm(res)
+        np.testing.assert_allclose(res_norm, 0.0, atol=1e-12, err_msg="residual")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/test_restart.py
+++ b/tests/unit_tests/test_restart.py
@@ -7,7 +7,7 @@ import sys
 baseDir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.join(baseDir, "../reg_tests"))
 
-from reg_aeroproblems import ap_tutorial_wing
+from reg_aeroproblems import ap_tutorial_wing  # noqa E402
 
 
 class BasicTests(unittest.TestCase):

--- a/tests/unit_tests/test_restart.py
+++ b/tests/unit_tests/test_restart.py
@@ -33,7 +33,7 @@ class BasicTests(unittest.TestCase):
         CFDSolver = ADFLOW(options=self.options, debug=False)
         res = CFDSolver.getResidual(ap_tutorial_wing)
         res_norm = np.linalg.norm(res)
-        np.testing.assert_allclose(res_norm, 0.0, atol=1e-12, err_msg="residual")
+        np.testing.assert_allclose(res_norm, 0.0, atol=1e-11, err_msg="residual")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Purpose
This PR addresses issue #199 
This would only effect cases were a solution file is being read by a case with split blocks (blocks are split for load balancing).
This did not show up in our tests because our test meshes have lots of blocks and we test with only 2 procs so there is no need to split any blocks.

There was a change in behavior from CGNS 3.4 onward that affects how partial ranges of data are read from a CGNS file. 
Specifically, instead of using the range given, the rind cells are now added to the range. See [here for src with comment highlighting change](https://github.com/CGNS/CGNS/blob/55afcfec8a0c9503dfead89c3cec477283e4fc5a/src/cgns_internals.c#L9488-L9500)
But we were already doing this on the adflow level so it happened twice resulting in an invalid range. 
 The fix is simply to stop adding the rind cells to the range on the adflow level


## Expected time until merged
Urgent. The code on Main does not work as it should
1-2 days please

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
See the new test included in the PR

## Checklist
- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
