### PR TITLE
Quick bug fix in getSolution

### DIFF
--- a/src/solver/surfaceIntegrations.F90
+++ b/src/solver/surfaceIntegrations.F90
@@ -959,7 +959,7 @@ contains
        ! Extract the current family list
        nFam = famLists(iGroup, 1)
        famList => famLists(iGroup, 2:2+nFam-1)
-       funcValues = zero
+       funcValues(:, iGroup) = zero
        localVal = zero
 
        do sps=1, nTimeIntervalsSpectral


### PR DESCRIPTION
## Purpose
When you call `getSolution` with multiple families the values calculated by the earlier families are zeroed on the last iteration. 
I don't believe this was ever the intended behavior and frankly I'm surprised this was left on unfixed for so long.
When using `evalFunctions` 'getSolution` is called individually for each group which is why this isn't currently messing up everyone's cases


## Expected time until merged
1 week 

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Ask @lambe for his test script if you'd like

## Checklist
- [ ] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
