### PR TITLE
raise Error if a Mesh Cell is skewed above threshold

### DIFF
--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -4968,6 +4968,7 @@ class ADFLOW(AeroSolver):
             ],
             "turbulenceOrder": [str, ["first order", "second order"]],
             "turbResScale": [(float, list, type(None)), None],
+            "meshMaxSkewness": [float, 1.0],
             "turbulenceProduction": [str, ["strain", "vorticity", "Kato-Launder"]],
             "useQCR": [bool, False],
             "useRotationSA": [bool, False],
@@ -5318,6 +5319,7 @@ class ADFLOW(AeroSolver):
             },
             "turbulenceorder": {"first order": 1, "second order": 2, "location": ["discr", "orderturb"]},
             "turbresscale": ["iter", "turbresscale"],
+            "meshmaxskewness": ["iter", "meshmaxskewness"],
             "turbulenceproduction": {
                 "strain": self.adflow.constants.strain,
                 "vorticity": self.adflow.constants.vorticity,

--- a/src/f2py/adflow.pyf
+++ b/src/f2py/adflow.pyf
@@ -1104,6 +1104,7 @@ python module libadflow
          real(kind=realtype) allocatable,dimension(:) :: etark
          real(kind=realtype) allocatable,dimension(:) :: cdisrk
          real(kind=realtype), dimension(4) :: turbresscale
+         real(kind=realtype) :: meshmaxskewness
          logical :: freezeturbsource
          logical :: printiterations
          logical :: printwarnings

--- a/src/modules/block.F90
+++ b/src/modules/block.F90
@@ -385,6 +385,7 @@ module block
      !                         needed for unsteady problems on
      !                         deforming grids. Only allocated on
      !                         the finest grid level.
+     !  skew(0:ib,0:jb,0:kb)  - Skewness of Volume
      !  uv(2,2:il,2:jl,2:kl) - Parametric location on elemID for each cell.
      !                         Only used for fast wall distance calcs.
      !  porI(1:il,2:jl,2:kl) - Porosity in the i direction.
@@ -436,6 +437,7 @@ module block
      real(kind=realType), dimension(:,:,:),   pointer :: vol
      real(kind=realType), dimension(:,:,:,:), pointer :: volOld
      real(kind=realType), dimension(:,:,:),   pointer :: volref
+     real(kind=realType), dimension(:,:,:),   pointer :: skew
      real(kind=realType), dimension(:,:,:,:), pointer :: uv
      integer(kind=intType), dimension(:,:,:,:), pointer :: surfNodeIndices
 

--- a/src/modules/blockPointers.F90
+++ b/src/modules/blockPointers.F90
@@ -97,6 +97,7 @@ module blockPointers
   real(kind=realType), dimension(:,:,:),   pointer :: vol
   real(kind=realType), dimension(:,:,:),   pointer :: volref
   real(kind=realType), dimension(:,:,:,:), pointer :: volOld
+  real(kind=realType), dimension(:,:,:),   pointer :: skew
   real(kind=realType), dimension(:,:,:,:),   pointer :: dadidata
 
   integer(kind=porType), dimension(:,:,:), pointer :: porI, porJ, porK

--- a/src/modules/inputParam.F90
+++ b/src/modules/inputParam.F90
@@ -247,9 +247,11 @@ module inputIteration
   ! cdisRk:           Dissipative coefficients in the runge kutta
   !                   scheme. The values depend on the number of
   !                   stages specified.
-  ! printIterations: If True, iterations are printed to stdout
-  ! turbresscale: Scaling factor for turbulent residual. Necessary for
-  !            NKsolver with RANS. Only tested on SA.
+  ! printIterations:  If True, iterations are printed to stdout
+  ! turbresscale:     Scaling factor for turbulent residual. Necessary for
+  !                   NKsolver with RANS. Only tested on SA.
+  ! meshMaxSkewness   If one cell has a highe skewness than this, the Solver
+  !                   errors out.
   ! iterType : String used for specifying which type of iteration was taken
   !
   ! Definition of the string, which stores the multigrid cycling
@@ -285,6 +287,7 @@ module inputIteration
   logical :: printIterations
   logical :: printWarnings
   real(kind=realType), dimension(4) :: turbResScale
+  real(kind=realType) :: meshMaxSkewness
 
 end module inputIteration
 

--- a/src/preprocessing/preprocessingModules.F90
+++ b/src/preprocessing/preprocessingModules.F90
@@ -775,6 +775,8 @@ module checkVolBlock
 
      logical :: blockHasNegVol
      logical, dimension(:,:,:), pointer :: volumeIsNeg
+     logical :: blockHasSkewedVol
+     logical, dimension(:,:,:), pointer :: volumeIsSkewed
 
   end type checkVolBlockType
 

--- a/src/utils/utils.F90
+++ b/src/utils/utils.F90
@@ -3401,6 +3401,8 @@ end subroutine cross_prod
     volRef => flowDoms(nn,mm,ll)%volRef
     volOld => flowDoms(nn,1,ll)%volOld
 
+    skew   => flowDoms(nn,mm,ll)%skew
+
     porI => flowDoms(nn,mm,1)%porI
     porJ => flowDoms(nn,mm,1)%porJ
     porK => flowDoms(nn,mm,1)%porK


### PR DESCRIPTION
## Purpose
I am optimising a two element-airfoil. Because of the proximity of those elements, the mesh quality deteriorates fast. To fix this, i check if the variable `adflow.killsignals.fatalfail` is set to `true`. When this is the case, I regenerate a mesh.
Unfortunately, this method is to slow as the variable is only set when the mesh has negative volumes. 

This PR should addresses this in the following way: 
Calculate the skewness as described [here](https://www.simscale.com/docs/simulation-setup/meshing/mesh-quality/#skewness). If it goes above a certain threshold defined in the regular python-wrapper (e.g. `meshMaxSkewness: 0.4`), ADflow errors out by means of setting `adflow.killsignals.fatalfail` to `true`.

I do not consider this PR ready yet. But I want to get feeback from you guys as soon as possible. I am especially interested in these points:

1. I only calculate the skewness when we are actually interested in it (`meshMaxSkewness` < 1). Does this make sense?
1. Is highjacking the subroutine `WriteNegVolumes` fine as I did?
1.  I need to release my new `flowdom` variable `skew`. Where is the best place to do this?

## Expected time until merged
Probably a couple of weeks.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->
tbd

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
