### PR TITLE
Adding flag on complex build to support gcc 10 

### DIFF
--- a/src_cs/build/Makefile
+++ b/src_cs/build/Makefile
@@ -1,8 +1,11 @@
 # Include the user supplied makefile
 include ../../config/config.mk
 
+# Check compiler and version and add flags if needed
+EXTRA_FF90_FLAGS = $(shell bash ../../config/compilerCheck.sh $(FF90))
+
 # Group all the fortran, C and compiler flags together.
-FF90_ALL_FLAGS_NO_OPT = $(FF90_FLAGS) $(CGNS_INCLUDE_FLAGS) -I. -DUSE_COMPLEX \
+FF90_ALL_FLAGS_NO_OPT = $(FF90_FLAGS) $(EXTRA_FF90_FLAGS) $(CGNS_INCLUDE_FLAGS) -I. -DUSE_COMPLEX \
 		   $(PETSC_CC_INCLUDES) $(FF90_PRECISION_FLAGS)
 
 FF90_ALL_FLAGS = $(FF90_ALL_FLAGS_NO_OPT) $(FFXX_OPT_FLAGS)


### PR DESCRIPTION
## Purpose
This PR adds the `-fallow-argument-mismatch` flag to the complex build if it detects GCC version 10 and newer. This is equivalent to what was done in #244.

## Expected time until merged
Should be quick.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
Test compiling adflow with GCC 10+ either locally or in a container using the complex build.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
