### PR TITLE
Fixed f2py string intent

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     packages=find_packages(include=["adflow*"]),
     package_data={"adflow": ["*.so"]},
     install_requires=[
-        "numpy>=1.16,<1.22",
+        "numpy>=1.16,<1.24",
         "mdolab-baseclasses>=1.4",
         "mpi4py>=3.0",
         "petsc4py>=3.11",

--- a/src/f2py/adflow.pyf
+++ b/src/f2py/adflow.pyf
@@ -155,19 +155,19 @@ python module libadflow
          end subroutine setdefaultvalues
 
          subroutine monitorvariables(variables) ! in :test:monitorVariables.f90
-           character*(*) intent(inout) :: variables
+           character*(*) intent(in) :: variables
          end subroutine monitorvariables
 
          subroutine surfacevariables(variables) ! in :test:surfaceVariables.f90
-           character*(*) intent(inout) :: variables
+           character*(*) intent(in) :: variables
          end subroutine surfacevariables
 
          subroutine volumevariables(variables) ! in :test:volumeVariables.f90
-           character*(*) intent(inout) :: variables
+           character*(*) intent(in) :: variables
          end subroutine volumevariables
 
          subroutine isovariables(variables) ! in :test:volumeVariables.f90
-           character*(*) intent(inout) :: variables
+           character*(*) intent(in) :: variables
          end subroutine isovariables
 
          subroutine initializeisosurfacevariables(values,nvalues) ! in :test:setIsoSurfaceValues.F90


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
numpy 1.22 introduced some changes to how array dimensions are determined with f2py. From what I can tell, `intent(out)` strings of undetermined length are no longer valid (or have never been valid but did not previously raise an error).

ADflow has 4 string variables with `intent(inout)` that cause problems with numpy 1.22. I posted the error message in #256. However, we never use these variables in Python after passing them to Fortran, so I changed them to `intent(in)`. This fixes the error and does not change the behavior of the code.


## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
1 week

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->
I installed numpy 1.22, recompiled ADflow with these changes, and checked that all tests pass.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
