### PR TITLE
fixed minor formatting issue

### DIFF
--- a/src/utils/utils.F90
+++ b/src/utils/utils.F90
@@ -5708,7 +5708,7 @@ contains
         integer :: ierr
         character(len=maxStringLen) :: errorCodeFormat, errorLineFormat
 
-        errorCodeFormat = "(2(A, I2,)"
+        errorCodeFormat = "(2(A, I2))"
         errorLineFormat = "(A, I5, A, A)"
 
         if (errorcode == 0) then


### PR DESCRIPTION
## Purpose
Error check formatting string had a typo

## Expected time until merged


## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
