### PR TITLE
Added option to turn off negative volume print out

### DIFF
--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -5396,7 +5396,7 @@ class ADFLOW(AeroSolver):
             "printAllOptions": [bool, True],
             "setMonitor": [bool, True],
             "printWarnings": [bool, True],
-            "printNegativeVolumes": [bool, True],
+            "printNegativeVolumes": [bool, False],
             "monitorVariables": [list, ["cpu", "resrho", "resturb", "cl", "cd"]],
             "surfaceVariables": [list, ["cp", "vx", "vy", "vz", "mach"]],
             "volumeVariables": [list, ["resrho"]],

--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -5396,6 +5396,7 @@ class ADFLOW(AeroSolver):
             "printAllOptions": [bool, True],
             "setMonitor": [bool, True],
             "printWarnings": [bool, True],
+            "printNegativeVolumes": [bool, True],
             "monitorVariables": [list, ["cpu", "resrho", "resturb", "cl", "cd"]],
             "surfaceVariables": [list, ["cp", "vx", "vy", "vz", "mach"]],
             "volumeVariables": [list, ["resrho"]],
@@ -5771,6 +5772,7 @@ class ADFLOW(AeroSolver):
             # Misc Parameters
             "printiterations": ["iter", "printiterations"],
             "printwarnings": ["iter", "printwarnings"],
+            "printnegativevolumes": ["iter", "printnegativevolumes"],
             "printtiming": ["adjoint", "printtiming"],
             "setmonitor": ["adjoint", "setmonitor"],
             "storeconvhist": ["io", "storeconvinneriter"],

--- a/doc/options.yaml
+++ b/doc/options.yaml
@@ -1160,6 +1160,10 @@ printWarnings:
   desc: >
     Flag to print warning messages like for bad quality volumes, etc.
 
+printNegativeVolumes:
+  desc: >
+    Flag to print the block indices, cell center coordinates, and volume for each negative volume cell in the mesh.
+
 monitorVariables:
   desc: >
     List of the variables whose convergence should be monitored.

--- a/src/f2py/adflow.pyf
+++ b/src/f2py/adflow.pyf
@@ -1135,6 +1135,7 @@ python module libadflow
          logical :: freezeturbsource
          logical :: printiterations
          logical :: printwarnings
+         logical :: printnegativevolumes
          real(kind=realtype) ::maxl2deviationfactor
          logical :: uselinresmonitor
          logical :: usedisscontinuation

--- a/src/modules/inputParam.F90
+++ b/src/modules/inputParam.F90
@@ -283,6 +283,7 @@ module inputIteration
     logical :: freezeTurbSource
     logical :: printIterations
     logical :: printWarnings
+    logical :: printNegativeVolumes
     real(kind=realType), dimension(4) :: turbResScale
     logical :: useDissContinuation
     real(kind=realType) :: dissContMagnitude, dissContMidpoint, dissContSharpness

--- a/src/preprocessing/preprocessingAPI.F90
+++ b/src/preprocessing/preprocessingAPI.F90
@@ -2719,7 +2719,7 @@ contains
         use communication
         use inputTimeSpectral
         use checkVolBlock
-        use inputIteration
+        use inputIteration, only: printWarnings, printNegativeVolumes
         use utils, only: setPointers, terminate, returnFail
         use commonFormats, only: stringSpace, stringInt1
         implicit none
@@ -3266,7 +3266,9 @@ contains
                 ! Negative volumes present on the fine grid level. Print a
                 ! list of the bad volumes and terminate executation.
 
-                call writeNegVolumes(checkVolDoms)
+                if (printNegativeVolumes) then
+                    call writeNegVolumes(checkVolDoms)
+                end if
 
                 call returnFail("metric", &
                                 "Negative volumes present in grid.")


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
I added an option to turn off printing of the negative volume indices and coordinates. The printout is useful for debugging, but I find that it mainly pollutes the output during production runs.

Setting the option `printNegativeVolumes` to False will mean that messages like the following will not be printed:

```
#
#                      Error
# Negative volumes found in the grid.
# A list of the negative volumes is printed below
#
#
# Block domain.00006 contains the following negative volumes
#--------------------------------------------------------------------
#
# Indices (2,25,38), coordinates ( 4.114E+01, 8.003E+00,-6.111E-01), Volume: -1.080E-04
# Indices (3,25,38), coordinates ( 4.117E+01, 8.005E+00,-5.494E-01), Volume: -2.248E-05
# Indices (2,23,39), coordinates ( 4.241E+01, 9.122E+00,-5.432E-01), Volume: -3.067E-04
# Indices (3,23,39), coordinates ( 4.245E+01, 9.110E+00,-4.905E-01), Volume: -2.873E-04
# Indices (4,23,39), coordinates ( 4.249E+01, 9.106E+00,-4.271E-01), Volume: -1.384E-04
# Indices (2,24,39), coordinates ( 4.179E+01, 8.530E+00,-5.689E-01), Volume: -3.465E-04
# Indices (3,24,39), coordinates ( 4.183E+01, 8.528E+00,-5.090E-01), Volume: -2.921E-04
# Indices (4,24,39), coordinates ( 4.187E+01, 8.537E+00,-4.401E-01), Volume: -1.667E-04
# Indices (2,25,39), coordinates ( 4.112E+01, 8.013E+00,-6.323E-01), Volume: -9.895E-04
                                             .
                                             .
                                             .
```

The `returnFail` error message will still be printed, so it is still clear that negative volumes have been encountered:

```
#
#--------------------------- !!! Error !!! ----------------------------
#* returnFail called by processor 0
#* Run-time error in procedure metric
#* Error message: Negative volumes present in grid.
#*
#----------------------------------------------------------------------
#
```

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
1 week

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->
I tested it on a wing case with geometry changes that cause negative volumes, and the option behaves as expected.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [x] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
