### PR TITLE
Fix type bug pyf file

### DIFF
--- a/src/f2py/adflow.pyf
+++ b/src/f2py/adflow.pyf
@@ -1249,10 +1249,10 @@ python module libadflow
          character(len=maxstringlen) :: gmresorthogtype
          character(len=maxstringlen) :: localpctype
          character(len=maxstringlen) :: precondtype
-         real(kind=realtype) :: adjabstol
-         real(kind=realtype) :: adjdivtol
-         real(kind=realtype) :: adjreltol
-         real(kind=realtype) :: adjreltolrel
+         real(kind=alwaysrealtype) :: adjabstol
+         real(kind=alwaysrealtype) :: adjdivtol
+         real(kind=alwaysrealtype) :: adjreltol
+         real(kind=alwaysrealtype) :: adjreltolrel
          real(kind=realtype) :: adjmaxl2dev
          integer(kind=inttype) :: overlap
          integer(kind=inttype) :: adjmonstep
@@ -1456,7 +1456,7 @@ python module libadflow
           end module adjointvars
 
        module adjointpetsc
-         real(kind=realtype) :: adjresinit, adjresstart, adjresfinal
+         real(kind=alwaysrealtype) :: adjresinit, adjresstart, adjresfinal
        end module adjointpetsc
 
        module inputtsstabderiv ! in :test:inputParam.f90

--- a/tests/unit_tests/test_basics.py
+++ b/tests/unit_tests/test_basics.py
@@ -1,6 +1,8 @@
 import unittest
 import os
+import numpy as np
 from adflow import ADFLOW
+from adflow import ADFLOW_C
 
 
 baseDir = os.path.dirname(os.path.abspath(__file__))
@@ -13,6 +15,70 @@ class BasicTests(unittest.TestCase):
         gridFile = "input_files/mdo_tutorial_euler.cgns"
         options = {"gridfile": os.path.join(baseDir, "../../", gridFile)}
         ADFLOW(options=options, debug=False)
+
+    def verifyOptions(self, CFDSolver):
+        pythonOptions, deprecatedOptions, specialOptions = CFDSolver._getSpecialOptionLists()
+
+        for optionName in CFDSolver.defaultOptions:
+            optionName = optionName.lower()
+
+            if optionName in pythonOptions or optionName in deprecatedOptions or optionName in specialOptions:
+                # Ignore for now
+                continue
+
+            # Get the python value from the dict
+            value = CFDSolver.getOption(optionName)
+
+            # Treat all other options
+            if isinstance(CFDSolver.optionMap[optionName], dict):
+                # For values that are set in fortran using constant from fortran
+                # we just overwrite the python value. An example is "solutionprecision" which is
+                # a str value in python that corresponds to an integer in fortran, which sets a module variable precisionsol
+                module = CFDSolver.moduleMap[CFDSolver.optionMap[optionName]["location"][0]]
+                variable = CFDSolver.optionMap[optionName]["location"][1]
+                value = CFDSolver.optionMap[optionName][value.lower()]
+            else:
+                module = CFDSolver.moduleMap[CFDSolver.optionMap[optionName][0]]
+                variable = CFDSolver.optionMap[optionName][1]
+
+            # Fetch the variable value form the module
+            fortranValue = getattr(module, variable)
+
+            # Now check if the set parameter is correct in fortran
+            if type(value) is bool:
+                fortranValue = bool(fortranValue)
+
+            elif type(value) is str:
+                # To not mess string arrays too much the following converts string byte array to regular array and strip whitespace
+                fortranValue = str(np.array(fortranValue, dtype=str)).strip()
+
+            elif optionName == "mgstartlevel" and (value == -1 or value == 0):
+                # mgstartlevel is set in Fortran but the default value (-1) defaults to the coarsest level
+                # value of -1 or 0 should default to coarsest level, which is extracted based on the number of MG levels strategy
+
+                # Just overwrite value with what is set in fortran
+                value = CFDSolver.adflow.inputiteration.nmglevels
+
+            # Note/todo: When running in complex mode the real part is compared to the default value. Options should in most cases always be real, but are complex in fortran. This should be updated at some point.
+            self.assertEqual(value, fortranValue)
+
+    def cmplx_test_options(self):
+        """
+        Test that options are set properly from python to Fortran in complex mode
+        """
+        gridFile = "input_files/cube_4x4x4.cgns"
+        options = {"gridfile": os.path.join(baseDir, "../../", gridFile)}
+        CFDSolver = ADFLOW_C(options=options, debug=False)
+        self.verifyOptions(CFDSolver)
+
+    def test_options(self):
+        """
+        Test that options are set properly from python to Fortran
+        """
+        gridFile = "input_files/cube_4x4x4.cgns"
+        options = {"gridfile": os.path.join(baseDir, "../../", gridFile)}
+        CFDSolver = ADFLOW(options=options, debug=False)
+        self.verifyOptions(CFDSolver)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Purpose
This PR addresses a very subtle bug causing unspecified behavior when running in complex mode. This bug was uncovered while debugging the new Intel OneAPI compilers. 

Several parameters are defined as `real(kind=alwaysrealtype)` in fortran, but as `real(kind=realtype)` in the python interface. When complexifying, these are changed as specified in the pyf file (incorrectly) to `complex(kind=8)`. This means that when these particular variables are set from python, 8 bytes are set in fortran, i.e., the first 4 bytes (the actual variable), and the adjacent 4 bytes in memory, which in principle can be anything. In practice, it turned out to be overwriting some other options. 

In the case of the new Intel compilers, `vis4` was overwritten in fortran, after the option had been set correctly earlier, causing a strange convergence behavior. On the GCC images, the booleans `useALE` and `updateWallDistanceUnsteady` are changed to false. The tests did not catch this, as they are both time-accurate options and current regression tests do not include complex tests. 

To prevent this happening again, a unit test is added to check that the parameters that are set from python are set to the expected value in fortran after the initialization of the solver. 


## Expected time until merged
Few days.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Run the included unit test without and with the fix.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
