### PR TITLE
Bug fix in blockette code from 2019

### DIFF
--- a/src/NKSolver/blockette.F90
+++ b/src/NKSolver/blockette.F90
@@ -578,7 +578,7 @@ contains
                         do k = 1, ke
                             do j = 1, je
                                 do i = 0, ie
-                                    sFaceI(i, j, k) = bsFaceI(ii + ii - 2, j + jj - 2, k + kk - 2)
+                                    sFaceI(i, j, k) = bsFaceI(i + ii - 2, j + jj - 2, k + kk - 2)
                                 end do
                             end do
                         end do
@@ -586,7 +586,7 @@ contains
                         do k = 1, ke
                             do j = 0, je
                                 do i = 1, ie
-                                    sFaceJ(i, j, k) = bsFaceJ(ii + ii - 2, j + jj - 2, k + kk - 2)
+                                    sFaceJ(i, j, k) = bsFaceJ(i + ii - 2, j + jj - 2, k + kk - 2)
                                 end do
                             end do
                         end do
@@ -594,7 +594,7 @@ contains
                         do k = 0, ke
                             do j = 1, je
                                 do i = 1, ie
-                                    sFaceK(i, j, k) = bsFaceK(ii + ii - 2, j + jj - 2, k + kk - 2)
+                                    sFaceK(i, j, k) = bsFaceK(i + ii - 2, j + jj - 2, k + kk - 2)
                                 end do
                             end do
                         end do


### PR DESCRIPTION
## Purpose

The blockette code had a bug when transferring face velocities to the blockette data. This code is not used for steady state, non rotating meshes. I am not sure if this was the reason rotating cases were not working with blockettes or we ignored some other terms as well. 

## Expected time until merged
Instant-merge

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
