### PR TITLE
Fixed rotation rate for local blocks

### DIFF
--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -1201,7 +1201,9 @@ class ADFLOW(AeroSolver):
             # By Default set all the blocks:
             cgnsBlocks = numpy.arange(1, self.adflow.cgnsgrid.cgnsndom + 1)
 
-        self.adflow.preprocessingapi.updaterotationrate(rotCenter, rotations, cgnsBlocks)
+        nBlocks = len(cgnsBlocks)
+
+        self.adflow.preprocessingapi.updaterotationrate(rotCenter, rotations, cgnsBlocks, nBlocks)
         self._updateVelInfo = True
 
     def checkPartitioning(self, nprocs):
@@ -3671,6 +3673,7 @@ class ADFLOW(AeroSolver):
         groupArray = numpy.zeros((len(groupNames), nMax + 1))
         for i in range(len(groupNames)):
             famList = self._getFamilyList(groupNames[i])
+            
             groupArray[i, 0] = len(famList)
             groupArray[i, 1 : 1 + len(famList)] = famList
 
@@ -4538,7 +4541,6 @@ class ADFLOW(AeroSolver):
 
         # Extract any possibly BC daa
         bcDataNames, bcDataValues, bcDataFamLists, bcDataFams, bcVarsEmpty = self._getBCDataFromAeroProblem(self.curAP)
-
         # Do actual Fortran call.
         xvbar, extrabar, wbar, bcdatavaluesbar = self.adflow.adjointapi.computematrixfreeproductbwd(
             resBar,
@@ -4555,7 +4557,6 @@ class ADFLOW(AeroSolver):
             bcDataFamLists,
             bcVarsEmpty,
         )
-
         # Assemble the possible returns the user has requested:
         returns = []
         if wDeriv:
@@ -6019,6 +6020,7 @@ class ADFLOW(AeroSolver):
             "mavgptot": self.adflow.constants.costfuncmavgptot,
             "aavgptot": self.adflow.constants.costfuncaavgptot,
             "aavgps": self.adflow.constants.costfuncaavgps,
+            "mavgrho": self.adflow.constants.costfuncmavgrho,
             "mavgttot": self.adflow.constants.costfuncmavgttot,
             "mavgps": self.adflow.constants.costfuncmavgps,
             "mavgmn": self.adflow.constants.costfuncmavgmn,

--- a/src/preprocessing/preprocessingAPI.F90
+++ b/src/preprocessing/preprocessingAPI.F90
@@ -4073,11 +4073,11 @@ contains
         groundlevel = 1
 
         do nn = 1, nblocks
-            cgnsDoms(nn)%rotRate = rotRate
-            cgnsDoms(nn)%rotCenter = rotCenter
+            cgnsDoms(blocks(nn))%rotRate = rotRate
+            cgnsDoms(blocks(nn))%rotCenter = rotCenter
 
-            do i = 1, cgnsDoms(nn)%nBocos
-                cgnsDoms(nn)%bocoInfo(i)%rotRate = rotRate
+            do i = 1, cgnsDoms(blocks(nn))%nBocos
+                cgnsDoms(blocks(nn))%bocoInfo(i)%rotRate = rotRate
             end do
         end do
 


### PR DESCRIPTION
## Purpose
Fixes `setRotationRate(rotCenter, rotRate, cgnsBlocks=None)`. Currently when cgnsBlocks are passed, adflow adds rotation rate to 'n' cgnsBlocks starting from the first block number instead of applying the rotation rate to the specified block ids. The changes in this PR fix this bug.

## Expected time until merged
One week

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)

## Testing
Proper test case to be created.

## Checklist
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have tested locally that my fix is effective or that my feature works
