### PR TITLE
Option to specify number of leading zeros in solution filename number

### DIFF
--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -2738,14 +2738,15 @@ class ADFLOW(AeroSolver):
 
         # If we are numbering solution, it saving the sequence of
         # calls, add the call number
+        numDigits = self.getOption("writeSolutionDigits")
         if number is not None:
             # We need number based on the provided number:
-            baseName = baseName + "_%3.3d" % number
+            baseName = baseName + f"_%.{numDigits}d" % number
         else:
             # if number is none, i.e. standalone, but we need to
             # number solutions, use internal counter
             if self.getOption("numberSolutions"):
-                baseName = baseName + "_%3.3d" % self.curAP.adflowData.callCounter
+                baseName = baseName + f"_%.{numDigits}d" % self.curAP.adflowData.callCounter
 
         # Join to get the actual filename root
         base = os.path.join(outputDir, baseName)
@@ -5706,6 +5707,7 @@ class ADFLOW(AeroSolver):
             "partitionLikeNProc": [int, -1],
             # Misc Parameters
             "numberSolutions": [bool, True],
+            "writeSolutionDigits": [int, 3],
             "printIterations": [bool, True],
             "printTiming": [bool, True],
             "printIntro": [bool, True],
@@ -6199,6 +6201,7 @@ class ADFLOW(AeroSolver):
 
         pythonOptions = {
             "numbersolutions",
+            "writesolutiondigits",
             "writetecplotsurfacesolution",
             "coupledsolution",
             "partitiononly",

--- a/adflow/pyADflow.py
+++ b/adflow/pyADflow.py
@@ -1305,7 +1305,8 @@ class ADFLOW(AeroSolver):
                 )
 
         if self.adflow.killsignals.fatalfail:
-            fileName = f"failed_mesh_{self.curAP.name}_{self.curAP.adflowData.callCounter:03}.cgns"
+            numDigits = self.getOption("writeSolutionDigits")
+            fileName = f"failed_mesh_{self.curAP.name}_{self.curAP.adflowData.callCounter:0{numDigits}}.cgns"
             self.pp(f"Fatal failure during mesh warp! Bad mesh is written in output directory as {fileName}")
             self.writeMeshFile(os.path.join(self.getOption("outputDirectory"), fileName))
             self.curAP.fatalFail = True

--- a/doc/options.yaml
+++ b/doc/options.yaml
@@ -1220,7 +1220,7 @@ numberSolutions:
   desc: >
     Flag to set whether to attach the numbering of the AeroProblem to the grid solution file.
 
-numberSolutionDigits:
+writeSolutionDigits:
   desc: >
     Number of digits in the solution output filenames.
     A value of 4 will give, for example, 0023, while a value of 3 will give 023.

--- a/doc/options.yaml
+++ b/doc/options.yaml
@@ -1220,6 +1220,11 @@ numberSolutions:
   desc: >
     Flag to set whether to attach the numbering of the AeroProblem to the grid solution file.
 
+numberSolutionDigits:
+  desc: >
+    Number of digits in the solution output filenames.
+    A value of 4 will give, for example, 0023, while a value of 3 will give 023.
+
 printIterations:
   desc: >
     Flag to set whether to print out the monitoring values at each iteration.


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
In the existing version, the output file numbering is hard coded to be three digits long (e.g. 003). If there are more than 999 output files, the number is extended to four digits. This messes with file sorting in some cases because the 1001th case can come between the 101st and 102nd, depending on the sorting algorithm.

This PR adds a new option, `writeSolutionDigits`, to manually specify the number of digits in the output filename to get around this sorting problem.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
A few days

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->
Run a case that writes out solution files. Try changing the `writeSolutionDigits` option to something other than the default of 3 and observe that the output filenames change.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [x] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
