### PR TITLE
Fix filename in cgns export unsteady sims

### DIFF
--- a/src/output/writeCGNSSurface.F90
+++ b/src/output/writeCGNSSurface.F90
@@ -325,10 +325,15 @@ contains
             write (intString, "(i4.4)") timeStepUnsteady + nTimeStepsRestart
             intString = adjustl(intString)
 
-            surfSolFileNames(1) = trim(surfaceSolFile)//"&
-                 &Timestep"//trim(intString)
+            ! Locate the file extension (.cgns) and insert the timestep before it
+            if (index(trim(surfaceSolFile), ".cgns") > 0) then
+                surfSolFileNames(1) = trim(surfaceSolFile(1:index(trim(surfaceSolFile), ".cgns")-1)) // &
+                                      "_Timestep" // trim(intString) // ".cgns"
+            else
+                ! If no .cgns is found, append normally
+                surfSolFileNames(1) = trim(surfaceSolFile) // "_Timestep" // trim(intString)
+            endif
 
-            !===============================================================
 
         case (timeSpectral)
 


### PR DESCRIPTION
## Purpose
<!--
ADflow exports the surface cgns files as <name>.cgnstimestep<num> whereas it should be <name>_<timestep>.cgns. Bottom line is to have nothing after "cgns" in filename.cgns
It is very cumbersome to read these files especially in paraview as I have to rename all the files to <name>_<timestep>.cgns else paraview does not even recognize them, let alone detect and temporal sequence of files from an unsteady simulation. This is a convenience problem.
-->

## Expected time until merged
<!--
This PR is non-urgent. However, pls merge it when possible so the community can benefit. 
-->

## Type of change
<!--
It is a change to aid better filename export for the unsteady simulations cgns filenames.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [  ] New feature (non-breaking change which adds functionality)
- [  ] Breaking change (non-backwards-compatible fix or feature)
- [  ] Code style update (formatting, renaming)
- [  ] Refactoring (no functional changes, no API changes)
- [  ] Documentation update
- [  ] Maintenance update
- [  ] Other (please describe)

## Testing
<!-- Pls run any unsteady simulation with ADflow and select the cgns surface write option (cgns surface only, not tecplot) and the filenames should appear correctly with a .cgns -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [x] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [  ] I have run unit and regression tests which pass locally with my changes
- [  ] I have added new tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
