### PR TITLE
Fixed an MPhys issue with setting scalars with Numpy 2.4

### DIFF
--- a/adflow/mphys/mphys_adflow.py
+++ b/adflow/mphys/mphys_adflow.py
@@ -206,7 +206,11 @@ def setAeroProblem(solver, ap, ap_vars, inputs=None, outputs=None, print_dict=Tr
         tmp = {}
         for args, _ in ap_vars:
             name = args[0]
-            tmp[name] = inputs[name]
+            # This is a fix to support Numpy 2.4 until OpenMDAO supports it
+            if np.shape(inputs[name]) == (1,):
+                tmp[name] = inputs[name][0]
+            else:
+                tmp[name] = inputs[name]
 
         ap.setDesignVars(tmp)
         if solver.comm.rank == 0 and print_dict:

--- a/adflow/mphys/mphys_adflow.py
+++ b/adflow/mphys/mphys_adflow.py
@@ -206,7 +206,7 @@ def setAeroProblem(solver, ap, ap_vars, inputs=None, outputs=None, print_dict=Tr
         tmp = {}
         for args, _ in ap_vars:
             name = args[0]
-            # This is a fix to support Numpy 2.4 until OpenMDAO supports it
+            # Ensure values passed to aeroProblem are scalars
             if np.shape(inputs[name]) == (1,):
                 tmp[name] = inputs[name][0]
             else:


### PR DESCRIPTION

## Purpose
The Mphys wrapper was not working with Numpy versions >2.4.
This is because as of Numpy 2.4 1D vectors of length 1 can no longer be treated as scalar data types.
This issue manifested when ADflow tried to print the alpha value set by OpenMDAO.
We now check if we are setting a 1D array of len(1) and explicitly index the first entry to get a scalar 
data type.

## Expected time until merged
1-2 days

## Type of change


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
No new test required since we don't test on Numpy 2.4 yet.
This is just getting ahead of the issue.
The fix may no longer be needed if OpenMDAO changes something upstream
to account for this.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `ruff check` and `ruff format` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
