### PR TITLE
Add includeZipper option to mphys_get_triangulated_surface

### DIFF
--- a/adflow/mphys/mphys_adflow.py
+++ b/adflow/mphys/mphys_adflow.py
@@ -257,13 +257,17 @@ class ADflowMesh(ExplicitComponent):
     def mphys_get_surface_mesh(self):
         return self.x_a0
 
-    def mphys_get_triangulated_surface(self, groupName=None):
+    def mphys_get_triangulated_surface(self, groupName=None, includeZipper=True):
         # this is a list of lists of 3 points
         # p0, v1, v2
+        # includeZipper=False returns the raw wall surface (all faces, no overset
+        # blanking and no zipper mesh), which is independent of the processor count.
+        # This is the appropriate choice when the surface is used as a geometry
+        # reference, e.g. for DVConstraints projections.
 
-        return self._getTriangulatedMeshSurface(groupName=groupName)
+        return self._getTriangulatedMeshSurface(groupName=groupName, includeZipper=includeZipper)
 
-    def _getTriangulatedMeshSurface(self, groupName=None, **kwargs):
+    def _getTriangulatedMeshSurface(self, groupName=None, includeZipper=True, **kwargs):
         """
         This function returns a trianguled verision of the surface
         mesh on all processors. The intent is to use this for doing
@@ -281,8 +285,10 @@ class ADflowMesh(ExplicitComponent):
 
         # Obtain the points and connectivity for the specified
         # groupName
-        pts = self.aero_solver.comm.allgather(self.aero_solver.getSurfaceCoordinates(groupName, **kwargs))
-        conn, faceSizes = self.aero_solver.getSurfaceConnectivity(groupName)
+        pts = self.aero_solver.comm.allgather(
+            self.aero_solver.getSurfaceCoordinates(groupName, includeZipper=includeZipper, **kwargs)
+        )
+        conn, faceSizes = self.aero_solver.getSurfaceConnectivity(groupName, includeZipper=includeZipper)
         conn = np.array(conn).flatten()
         conn = self.aero_solver.comm.allgather(conn)
         faceSizes = self.aero_solver.comm.allgather(faceSizes)
@@ -1320,9 +1326,9 @@ class ADflowMeshGroup(Group):
         # just pass through the call
         return self.surface_mesh.mphys_add_coordinate_input()
 
-    def mphys_get_triangulated_surface(self):
+    def mphys_get_triangulated_surface(self, includeZipper=True):
         # just pass through the call
-        return self.surface_mesh.mphys_get_triangulated_surface()
+        return self.surface_mesh.mphys_get_triangulated_surface(includeZipper=includeZipper)
 
 
 class ADflowBuilder(Builder):


### PR DESCRIPTION


## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->

I started having issues with the thickness constraint projection with a geometry that was working before when running on a specific number of processors, but not with others (for example, the code worked for 24 cores but not for 20). I saw that the triangulated mesh surface returned by ADFlow when using for example 20 cores had a big gap that caused the constraint projection to fail there.

The mphys triangulated-surface helper always returned the zippered wall surface (includeZipper=True). For overset meshes that surface depends on the overset hole-cut/zipper, which is partition-dependent: at some MPI rank counts wall faces near overset overlaps are blanked and not recovered for a single-family request, leaving holes in the gathered surface.

When the surface is used as a geometry reference (e.g. DVConstraints thickness/volume constraint projections) this caused projection failures that appeared or disappeared depending only on the processor count.

Expose includeZipper (default True, so no behaviour change) on mphys_get_triangulated_surface / _getTriangulatedMeshSurface and the ADflowMeshGroup pass-through, forwarding it to both getSurfaceCoordinates and getSurfaceConnectivity so callers can request the raw, processor-count independent wall surface with includeZipper=False.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->

Not urgent, 2 weeks

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `ruff check` and `ruff format` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
